### PR TITLE
Downgrade ubuntu version

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,14 +9,16 @@ on:
   workflow_dispatch:
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
+      - name: check gclib version
+        run: ldd --version
       - name: Check out code
         uses: actions/checkout@v3
       - name: cargo fmt --check
         run: cargo fmt --check
   tests-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
`GLIBC` version in owa-build agents is lower than the ones here, because of that `*.node` files cannot be used in there.