### PR TITLE
Matching ignored dirs will be added as source files with empty impot map

### DIFF
--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,33 +1,33 @@
 import test from 'ava'
 
-import {goodFences} from '../index.js'
+import {goodFences, GoodFencesResultType} from '../index.js'
 
 test('run tests/good_fences_integration through napi', (t) => {
-  t.is(
-    goodFences({
-      paths: ["tests/good_fences_integration/src"],
-      project: "tests/good_fences_integration/tsconfig.json",
-    }).length, 6
-  )
+  const result = goodFences({
+    paths: ["tests/good_fences_integration/src"],
+    project: "tests/good_fences_integration/tsconfig.json",
+  });
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.EvaluationError).length, 0)
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.Violation).length, 6)
 })
 
 test('run tests/good_fences_integration through napi ignoring componentA', (t) => {
-  t.is(
-    goodFences({
-      paths: ["tests/good_fences_integration/src"],
-      project: "tests/good_fences_integration/tsconfig.json",
-      ignoredDirs: ['componentA']
-    }).length, 2
-  )
+  const result = goodFences({
+    paths: ["tests/good_fences_integration/src"],
+    project: "tests/good_fences_integration/tsconfig.json",
+    ignoredDirs: ['componentA'],
+  });
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.EvaluationError).length, 1);
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.Violation).length, 2);
 })
 
 test('run tests/good_fences_integration through napi ignoring componentA and complexComponentA', (t) => {
-  t.is(
-    goodFences({
-      paths: ["tests/good_fences_integration/src"],
-      project: "tests/good_fences_integration/tsconfig.json",
-      ignoredDirs: ['componentA', 'complexComponentA'],
-    }).length, 1
-  )
+  const result = goodFences({
+    paths: ["tests/good_fences_integration/src"],
+    project: "tests/good_fences_integration/tsconfig.json",
+    ignoredDirs: ['componentA', 'complexComponentA'],
+  });
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.EvaluationError).length, 1);
+  t.is(result.filter(r => r.resultType === GoodFencesResultType.Violation).length, 1);
 })
 

--- a/good-fences.js
+++ b/good-fences.js
@@ -24,7 +24,7 @@ const result = goodFences({
     paths: args ?? [],
     project: options.project,
     baseUrl: options.baseUrl,
-    errOutputPath: options.errOutputPath,
+    errOutputPath: options.output,
     ignoreExternalFences: options.ignoreExternalFences ? 1 : 0,
     ignoredDirs: options.ignoredDirs
 });

--- a/good-fences.js
+++ b/good-fences.js
@@ -13,7 +13,7 @@
      .option('-o, --output <string>', 'path to write found violations')
      .option('--baseUrl <string>', "Overrides `compilerOptions.baseUrl` property read from '--project' argument")
      .option('--ignoreExternalFences', 'Ignore external fences (e.g. those in `node_modules`)', false)
-     .option('--ignoredDirs [pathRegexs...]', 'Directories matching given regular expressions are excluded from fence evaluation (e.g. `--ignoreDirs lib` will not evaluate source files in all dirs named `lib`', [])
+     .option('--ignoredDirs [pathRegexs...]', 'Files under directories matching given regular expressions are excluded from fence evaluation and will not generate an import map but they are going to be included in the list sources and a fence configuration is still attached to their path (e.g. `--ignoreDirs lib` will not evaluate source files in all dirs named `lib`)', [])
      .arguments('<path> [morePaths...]', 'Dirs to look for fence and source files')
  program.parse(process.argv);
  

--- a/good-fences.js
+++ b/good-fences.js
@@ -9,26 +9,27 @@
  
  
  program
-     .option('-p, --project <string> ', 'tsconfig.json file path, defaults `./tsconfig.json`')
-     .option('-o, --output <string>', 'path to write found violations')
-     .option('--baseUrl <string>', "Overrides `compilerOptions.baseUrl` property read from '--project' argument")
-     .option('--ignoreExternalFences', 'Ignore external fences (e.g. those in `node_modules`)', false)
-     .option('--ignoredDirs [pathRegexs...]', 'Files under directories matching given regular expressions are excluded from fence evaluation and will not generate an import map but they are going to be included in the list sources and a fence configuration is still attached to their path (e.g. `--ignoreDirs lib` will not evaluate source files in all dirs named `lib`)', [])
-     .arguments('<path> [morePaths...]', 'Dirs to look for fence and source files')
- program.parse(process.argv);
+    .option('-p, --project <string> ', 'tsconfig.json file path, defaults `./tsconfig.json`', 'tsconfig.json')
+    .option('-o, --output <string>', 'path to write found violations')
+    .option('--baseUrl <string>', "Overrides `compilerOptions.baseUrl` property read from '--project' argument")
+    .option('--ignoreExternalFences', 'Ignore external fences (e.g. those in `node_modules`)', false)
+    .option('--ignoredDirs [pathRegexs...]', 'Files under directories matching given regular expressions are excluded from fence evaluation and will not generate an import map but they are going to be included in the list sources and a fence configuration is still attached to their path (e.g. `--ignoreDirs lib` will not evaluate source files in all dirs named `lib`)', [])
+    .arguments('<path> [morePaths...]', 'Dirs to look for fence and source files')
+program.parse(process.argv);
  
 const options = program.opts();
 const args = program.args;
 
- const result = goodFences({
-    paths: args,
+const result = goodFences({
+    paths: args ?? [],
     project: options.project,
     baseUrl: options.baseUrl,
     errOutputPath: options.errOutputPath,
     ignoreExternalFences: options.ignoreExternalFences ? 1 : 0,
     ignoredDirs: options.ignoredDirs
 });
- result.forEach(r => {
-     console.error(r.detailedMessage);
- });
+
+result.forEach(r => {
+    console.error(r.detailedMessage);
+});
  

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -91,3 +91,54 @@ impl Display for OpenTsConfigError {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct ResolvedImportNotFound {
+    pub project_local_path_str: String,
+    pub source_file_path: String,
+    pub import_specifier: String,
+}
+
+#[derive(Debug)]
+pub enum EvaluateFencesError {
+    IgnoredDir(ResolvedImportNotFound), // In case the resolve_ts_import finds a file but it matches any ignoredDirs and is not in source_file_map
+    NotScanned(ResolvedImportNotFound), // In case resolve_ts_import finds a file but is not in source_file_map and does not match any ignoredDirs (e.g. running good-fences only on packages and not in shared)
+    ImportNotResolved {
+        // In case the resolve_ts_import fails to find file
+        import_specifier: String,
+        source_file_path: String,
+    },
+}
+
+impl Error for EvaluateFencesError {}
+
+impl Display for EvaluateFencesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvaluateFencesError::IgnoredDir(err) => {
+                write!(
+                    f,
+                    "Resolved import path {} for {} specifier at {} matched ignored dirs regex, excluded from file scanning",
+                    err.project_local_path_str, err.import_specifier, err.source_file_path
+                )
+            }
+            EvaluateFencesError::NotScanned(err) => {
+                write!(
+                    f,
+                    "could not find project local path {} imported by {} with specifier {}",
+                    err.project_local_path_str, err.source_file_path, err.import_specifier
+                )
+            }
+            EvaluateFencesError::ImportNotResolved {
+                import_specifier,
+                source_file_path,
+            } => {
+                write!(
+                    f,
+                    "Unable to resolve import at with specifier {} at {}",
+                    import_specifier, source_file_path
+                )
+            }
+        }
+    }
+}

--- a/src/evaluate_fences.rs
+++ b/src/evaluate_fences.rs
@@ -73,11 +73,7 @@ pub fn evaluate_fences<'fencecollectionlifetime, 'sourcefilelifetime>(
     ignored_dirs: Option<&Vec<regex::Regex>>,
 ) -> Result<Option<Vec<ImportRuleViolation<'fencecollectionlifetime, 'sourcefilelifetime>>>, String>
 {
-    for reg in ignored_dirs.unwrap_or(&EMPTY_REGEX_VEC) {
-        if reg.is_match(&source_file.source_file_path.as_str()) {
-            return Ok(None);
-        }
-    }
+    let ignored_dirs = ignored_dirs.unwrap_or(&EMPTY_REGEX_VEC);
 
     let mut violations = Vec::<ImportRuleViolation>::new();
     let source_fences: Vec<&'fencecollectionlifetime Fence> =
@@ -101,6 +97,12 @@ pub fn evaluate_fences<'fencecollectionlifetime, 'sourcefilelifetime>(
                 // grab the project local file, check our tags against the exports of the
                 // fences of the file we are importing.
                 ResolvedImport::ProjectLocalImport(project_local_path) => {
+                    if ignored_dirs
+                        .iter()
+                        .any(|d| d.is_match(project_local_path.to_str().unwrap()))
+                    {
+                        continue;
+                    }
                     let project_local_path_str = project_local_path.to_str().unwrap();
                     let imported_source_file_opt = source_files.get(no_ext(project_local_path_str));
                     let imported_source_file_with_idx_opt = if imported_source_file_opt.is_none() {

--- a/src/evaluate_fences.rs
+++ b/src/evaluate_fences.rs
@@ -97,13 +97,14 @@ pub fn evaluate_fences<'fencecollectionlifetime, 'sourcefilelifetime>(
                 // grab the project local file, check our tags against the exports of the
                 // fences of the file we are importing.
                 ResolvedImport::ProjectLocalImport(project_local_path) => {
+                    let project_local_path_str = project_local_path.to_str().unwrap();
                     if ignored_dirs
                         .iter()
-                        .any(|d| d.is_match(project_local_path.to_str().unwrap()))
+                        .any(|d| d.is_match(project_local_path_str))
                     {
                         continue;
                     }
-                    let project_local_path_str = project_local_path.to_str().unwrap();
+
                     let imported_source_file_opt = source_files.get(no_ext(project_local_path_str));
                     let imported_source_file_with_idx_opt = if imported_source_file_opt.is_none() {
                         let mut clone_path_with_idx = project_local_path.clone();

--- a/src/good_fences_runner.rs
+++ b/src/good_fences_runner.rs
@@ -89,7 +89,6 @@ impl GoodFencesRunner {
 
     pub fn find_import_violations<'a>(
         &'a self,
-        ignored_dirs: Vec<regex::Regex>,
     ) -> Vec<Result<ImportRuleViolation<'a, 'a>, String>> {
         println!("Evaluating {} files", self.source_files.keys().len());
         let mut all_violations: Vec<Result<ImportRuleViolation<'a, 'a>, String>> = vec![];
@@ -103,7 +102,6 @@ impl GoodFencesRunner {
                     &self.source_files,
                     &self.tsconfig_paths_json,
                     &source_file,
-                    Some(&ignored_dirs),
                 )
             })
             .collect::<Vec<_>>();
@@ -518,7 +516,7 @@ mod test {
             &Vec::new(),
         );
 
-        let mut violations = good_fences_runner.find_import_violations(vec![]);
+        let mut violations = good_fences_runner.find_import_violations();
         violations.sort_by(compare_violations);
 
         let rule = ExportRule {

--- a/src/good_fences_runner.rs
+++ b/src/good_fences_runner.rs
@@ -33,12 +33,7 @@ impl GoodFencesRunner {
         // find files
         let walked_files = directory_paths_to_walk
             .iter()
-            .map(|path| {
-                if ignored_dirs.iter().any(|d| d.is_match(path)) {
-                    return vec![WalkFileData::Nothing];
-                }
-                discover_fences_and_files(path, external_fences, ignored_dirs.clone())
-            })
+            .map(|path| discover_fences_and_files(path, external_fences, ignored_dirs.clone()))
             .flatten();
 
         let (fences_wrapped, sources_wrapped): (Vec<WalkFileData>, Vec<WalkFileData>) =

--- a/src/good_fences_runner.rs
+++ b/src/good_fences_runner.rs
@@ -33,7 +33,12 @@ impl GoodFencesRunner {
         // find files
         let walked_files = directory_paths_to_walk
             .iter()
-            .map(|path| discover_fences_and_files(path, external_fences, ignored_dirs.clone()))
+            .map(|path| {
+                if ignored_dirs.iter().any(|d| d.is_match(path)) {
+                    return vec![WalkFileData::Nothing];
+                }
+                discover_fences_and_files(path, external_fences, ignored_dirs.clone())
+            })
             .flatten();
 
         let (fences_wrapped, sources_wrapped): (Vec<WalkFileData>, Vec<WalkFileData>) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesError> {
     );
 
     println!("beginning fence evaluations");
-    let violations = good_fences_runner.find_import_violations(ignored_dirs_regexs);
+    let violations = good_fences_runner.find_import_violations();
     let elapsed = start.elapsed();
 
     // Print results and statistics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
+use error::EvaluateFencesError;
+use napi::bindgen_prelude::ToNapiValue;
 use napi_derive::napi;
 use serde::Serialize;
 use std::time::Instant;
 use walk_dirs::ExternalFences;
-
 pub mod error;
 pub mod evaluate_fences;
 pub mod fence;
@@ -15,7 +16,7 @@ mod path_utils;
 pub mod walk_dirs;
 
 #[napi]
-pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesError> {
+pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesResult> {
     let start = Instant::now();
     let tsconfig_path = opts.project;
     let mut tsconfig = import_resolver::TsconfigPathsJson::from_path(tsconfig_path)
@@ -40,36 +41,46 @@ pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesError> {
     );
 
     println!("beginning fence evaluations");
-    let violations = good_fences_runner.find_import_violations();
+    let eval_results = good_fences_runner.find_import_violations();
     let elapsed = start.elapsed();
 
     // Print results and statistics
-    println!("Violations: {:#?}", violations);
-    println!("Total violations: {}", violations.len());
-    let errors: Vec<GoodFencesError> = violations
-        .iter()
-        .filter_map(|violation| -> Option<GoodFencesError> {
-            match violation {
-                Ok(v) => {
-                    return Some(GoodFencesError {
-                        message: "".to_owned(),
-                        source_file: Some(v.violating_file_path.to_string()),
-                        raw_import: Some(v.violating_import_specifier.to_string()),
-                        fence_path: Some(v.violating_fence.fence_path.clone()),
-                        detailed_message: format!(
-                            "Good-fences violation in {}\n",
-                            &v.violating_file_path
-                        )
-                        .to_string(),
-                    })
-                }
-                Err(_) => return None,
-            }
-        })
-        .collect();
+    println!("Violations: {:#?}", eval_results.violations);
+    println!("Evalation errors: {:#?}", eval_results.evaluation_errors);
+    println!("Total violations: {}", eval_results.violations.len());
+    println!("Total errors: {}", eval_results.evaluation_errors.len());
+
+    let mut errors: Vec<GoodFencesResult> = Vec::new();
+
+    eval_results.violations.iter().for_each(|v| {
+        errors.push(GoodFencesResult {
+            result_type: GoodFencesResultType::Violation,
+            message: "Good fences violation".to_owned(),
+            source_file: Some(v.violating_file_path.to_owned()),
+            raw_import: Some(v.violating_import_specifier.to_owned()),
+            fence_path: Some(v.violating_fence.fence_path.to_owned()),
+            detailed_message: format!("Good-fences violation in {}\n", &v.violating_file_path),
+        });
+    });
+
+    eval_results.evaluation_errors.iter().for_each(|e| {
+        errors.push(GoodFencesResult {
+            result_type: GoodFencesResultType::EvaluationError,
+            message: e.to_string(),
+            source_file: None,
+            raw_import: None,
+            fence_path: None,
+            detailed_message: e.to_string(),
+        });
+    });
+
     // Write results to file
     if let Some(output) = opts.err_output_path {
-        write_violations_as_json(violations, output);
+        write_violations_as_json(
+            eval_results.violations,
+            eval_results.evaluation_errors,
+            output,
+        );
     }
 
     println!("Elapsed time since start: {:?}", elapsed);
@@ -99,8 +110,16 @@ pub struct GoodFencesOptions {
     pub ignored_dirs: Option<Vec<String>>,
 }
 
+#[derive(Eq, Debug, PartialEq)]
 #[napi]
-pub struct GoodFencesError {
+pub enum GoodFencesResultType {
+    EvaluationError = 0,
+    Violation = 1,
+}
+
+#[napi]
+pub struct GoodFencesResult {
+    pub result_type: GoodFencesResultType,
     pub message: String,
     pub source_file: Option<String>,
     pub raw_import: Option<String>,
@@ -109,39 +128,40 @@ pub struct GoodFencesError {
 }
 
 pub fn write_violations_as_json(
-    violations: Vec<Result<evaluate_fences::ImportRuleViolation, String>>,
+    violations: Vec<evaluate_fences::ImportRuleViolation>,
+    fence_eval_errors: Vec<EvaluateFencesError>,
     err_file_output_path: String,
 ) {
-    let unwraped_violations: Result<Vec<evaluate_fences::ImportRuleViolation>, String> =
-        violations.into_iter().collect();
-    match unwraped_violations {
-        Ok(v) => {
-            match std::fs::write(
-                &err_file_output_path,
-                serde_json::to_string_pretty(&JsonErrorFile { violations: v }).unwrap(),
-            ) {
-                Ok(_) => {
-                    let cwd = std::env::current_dir()
-                        .unwrap()
-                        .to_string_lossy()
-                        .to_string();
-                    println!(
-                        "Violations written to {}",
-                        format!("{} at {}", err_file_output_path, cwd)
-                    );
-                }
-                Err(err) => {
-                    eprintln!("Unable to write violations to {err_file_output_path}.\nError: {err}")
-                }
-            };
+    let evaluation_errors: Vec<String> = fence_eval_errors
+        .iter()
+        .map(|error| error.to_string())
+        .collect();
+    match std::fs::write(
+        &err_file_output_path,
+        serde_json::to_string_pretty(&JsonErrorFile {
+            violations,
+            evaluation_errors,
+        })
+        .unwrap(),
+    ) {
+        Ok(_) => {
+            let cwd = std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            println!(
+                "Violations written to {}",
+                format!("{} at {}", err_file_output_path, cwd)
+            );
         }
-        Err(e) => {
-            eprintln!("Error evaluating fences: {e}");
+        Err(err) => {
+            eprintln!("Unable to write violations to {err_file_output_path}.\nError: {err}")
         }
-    }
+    };
 }
 
 #[derive(Debug, Serialize)]
 pub struct JsonErrorFile<'a> {
     pub violations: Vec<evaluate_fences::ImportRuleViolation<'a, 'a>>,
+    pub evaluation_errors: Vec<String>,
 }

--- a/src/walk_dirs.rs
+++ b/src/walk_dirs.rs
@@ -6,7 +6,6 @@ use napi::bindgen_prelude::ToNapiValue;
 use path_slash::PathExt;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use std::fmt::format;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 extern crate pathdiff;

--- a/src/walk_dirs.rs
+++ b/src/walk_dirs.rs
@@ -54,9 +54,10 @@ lazy_static! {
     static ref WORKING_DIR_PATH: PathBuf = current_dir().unwrap();
 }
 
-pub fn discover_fences_and_files(
-    start_path: &str,
+pub fn discover_fences_and_files<'a>(
+    start_path: &'a str,
     ignore_external_fences: ExternalFences,
+    ignored_dirs: Vec<regex::Regex>,
 ) -> Vec<WalkFileData> {
     let walk_dir = WalkDirGeneric::<(TagList, WalkFileData)>::new(start_path).process_read_dir(
         move |read_dir_state, children| {
@@ -159,16 +160,26 @@ pub fn discover_fences_and_files(
 
                                     let source_file_path = slashed_as_relative_path(&file_path);
 
-                                    let imports = match get_imports_map_from_file(&file_path) {
-                                        Ok(imps) => imps,
-                                        Err(e) => {
-                                            eprintln!("Error {}", e);
-                                            continue;
+                                    let source_file_path_str =
+                                        source_file_path.unwrap().to_string();
+
+                                    let imports = if ignored_dirs
+                                        .iter()
+                                        .any(|r| r.is_match(&source_file_path_str))
+                                    {
+                                        HashMap::new()
+                                    } else {
+                                        match get_imports_map_from_file(&file_path) {
+                                            Ok(imps) => imps,
+                                            Err(e) => {
+                                                eprintln!("Error {}", e);
+                                                continue;
+                                            }
                                         }
                                     };
 
                                     dir_entry.client_state = WalkFileData::SourceFile(SourceFile {
-                                        source_file_path: source_file_path.unwrap().to_string(),
+                                        source_file_path: source_file_path_str,
                                         imports,
                                         tags: HashSet::from_iter(
                                             read_dir_state.iter().map(|x| x.to_owned()),
@@ -194,25 +205,11 @@ pub fn discover_fences_and_files(
         .collect();
 }
 
-// fn as_relative_path<'a>(file_path: &'a Path) -> Result<RelativePath, fmt::Error> {
-//     let slashed: PathBuf;
-//     #[cfg(target_os = "windows")] {
-//       slashed = match file_path.to_slash() {
-//         Some(slash_path) => PathBuf::from(slash_path.to_string()),
-//         None => {return Err() },
-//       }
-//     }
-//     #[cfg(not(target_os = "windows"))] {
-//       slashed = PathBuf::from(p)
-//     }
-//     return Ok(RelativePath::from_path(&slashed))
-//   }
-
 #[cfg(test)]
 mod test {
     use crate::fence::{Fence, ParsedFence};
     use crate::walk_dirs::{discover_fences_and_files, SourceFile, WalkFileData};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::iter::{FromIterator, Iterator};
 
     macro_rules! map(
@@ -244,6 +241,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "tests/walk_dir_simple",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected_root_fence = Fence {
@@ -275,6 +273,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "./tests/comments_panel_test",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected = "tests/comments_panel_test/packages/accelerator/accelerator-common/src/CommentsPanel/index.ts";
@@ -298,6 +297,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "tests/walk_dir_simple",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected_subsubdir_fence = Fence {
@@ -326,6 +326,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "tests/walk_dir_simple",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected_root_ts_file = SourceFile {
@@ -352,6 +353,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "tests/walk_dir_simple",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected_subdir_ts_file = SourceFile {
@@ -379,6 +381,7 @@ mod test {
         let discovered: Vec<WalkFileData> = discover_fences_and_files(
             "tests/walk_dir_simple",
             crate::walk_dirs::ExternalFences::Ignore,
+            Vec::new(),
         );
 
         let expected_subdir_ts_file = SourceFile {
@@ -391,6 +394,35 @@ mod test {
             imports: map!(
               "sub-sub-dir-file-abc-named-imports" => Option::Some(set!("a","b","c"))
             ),
+        };
+
+        assert!(
+            discovered.iter().any(|x| match x {
+                WalkFileData::SourceFile(y) => expected_subdir_ts_file == *y,
+                _ => false,
+            }),
+            "expected discovered files to contain {:?}, but it did not. Actual: {:?}",
+            expected_subdir_ts_file,
+            discovered
+        );
+    }
+
+    #[test]
+    fn test_retrieve_emtpy_imports_on_ignored_dirs_match() {
+        let discovered: Vec<WalkFileData> = discover_fences_and_files(
+            "tests/walk_dir_simple",
+            crate::walk_dirs::ExternalFences::Ignore,
+            vec![regex::Regex::new("tests/.**/subdir").unwrap()],
+        );
+
+        let expected_subdir_ts_file = SourceFile {
+            source_file_path: "tests/walk_dir_simple/subdir/subsubdir/subSubDirFile.ts".to_owned(),
+            tags: set!(
+                "root-fence-tag-1".to_owned(),
+                "root-fence-tag-2".to_owned(),
+                "subsubdir-fence-tag".to_owned()
+            ),
+            imports: HashMap::new(),
         };
 
         assert!(


### PR DESCRIPTION
Currently, `ignoredDirs` option only excludes files from being evaluated with their fence config. The problem is that even when files in `shared/.**/lib` or `dist` are not evaluated, their AST is still being parsed, considering that it is an expensive task to do, it is having an impact on performance.

- Files under matching `ignoredDirs` regexes will be ignored (sources and fences).
- Resolved import paths matching `ignoredDirs` are ignored, even if they would be violations.