### PR TITLE
Fixed action yml to avoid duplicated workflow on merge to main

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,8 +1,5 @@
 name: run unit tests
 on:
-  push:
-    branches:
-      - 'main'
   pull_request:
     branches: [main]
   workflow_call:

--- a/change/@good-fences-api-c672cfce-50b8-4ace-980f-961be664715d.json
+++ b/change/@good-fences-api-c672cfce-50b8-4ace-980f-961be664715d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed action yml to avoid duplicated workflow on merge to main",
+  "packageName": "@good-fences/api",
+  "email": "edgar21_9@hotmail.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
unittest is run as part of the publish flow, which is also triggered on `main`.
Therefore, the `unittest.yml` workflow does not need its own trigger on `main`.