### PR TITLE
enable find unused items within files

### DIFF
--- a/change/@good-fences-api-5d6cb165-1214-4a7d-aca8-f1cf100d7c5d.json
+++ b/change/@good-fences-api-5d6cb165-1214-4a7d-aca8-f1cf100d7c5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add feature to resolve export-from and track unused items",
+  "packageName": "@good-fences/api",
+  "email": "edgar21_9@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/unused_finder/graph.rs
+++ b/src/unused_finder/graph.rs
@@ -35,11 +35,14 @@ impl GraphFile {
         is_used: bool,
     ) -> Self {
         let mut export_from = HashMap::new();
-        import_export_info.export_from_ids.iter().for_each(|(source_file, items)| {
-            for item in items {
-                export_from.insert(item.into(), source_file.clone());
-            }
-        });
+        import_export_info
+            .export_from_ids
+            .iter()
+            .for_each(|(source_file, items)| {
+                for item in items {
+                    export_from.insert(item.into(), source_file.clone());
+                }
+            });
         Self {
             is_used,
             export_from,
@@ -104,13 +107,11 @@ impl<'a> Graph {
                 any_used = any_used || !imported_file.is_used;
                 // if `item` was already marked as used
                 match imported_file.mark_item_as_used(&item.into()) {
-                    MarkItemResult::MarkedAsUsed => {
-                        any_used = true
-                    },
-                    MarkItemResult::AlreadyMarked => {},
+                    MarkItemResult::MarkedAsUsed => any_used = true,
+                    MarkItemResult::AlreadyMarked => {}
                     MarkItemResult::ResolveExportFrom(origin) => {
                         pending_paths.push((origin, item));
-                    },
+                    }
                 }
             }
         }

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -147,17 +147,16 @@ pub fn find_unused_items(
         .par_iter_mut()
         .map(|file| {
             process_import_export_info(file, &resolver);
-            GraphFile {
-                file_path: file.source_file_path.clone(),
-                import_export_info: file.import_export_info.clone(),
-                is_used: entry_packages.contains(&file.package_name), // mark files from entry_packages as used
-                unused_exports: file
-                    .import_export_info
+            GraphFile::new(
+                file.source_file_path.clone(),
+                file.import_export_info
                     .exported_ids
                     .iter()
                     .map(|e| e.metadata.export_kind.clone())
                     .collect(),
-            }
+                file.import_export_info.clone(),
+                entry_packages.contains(&file.package_name), // mark files from entry_packages as used
+            )
         })
         .collect();
 
@@ -195,10 +194,22 @@ pub fn find_unused_items(
         }
     }
 
-    let unused_files = BTreeMap::from_iter(graph.files.drain().filter(|f| !f.1.is_used));
+    let unused_files = BTreeMap::from_iter(graph.files.iter().filter(|f| !f.1.is_used));
     let results: Vec<String> = unused_files
         .iter()
         .map(|f| format!("\"{}\",", f.0))
+        .chain(graph.files.iter().filter_map(|(path, file)| {
+            let items = file
+                .unused_exports
+                .iter()
+                .map(|items| items.to_string())
+                .collect::<Vec<_>>();
+            if items.len() > 0 {
+                let items = items.join(", ");
+                return Some(format!("From file \"{}\": {}", path, items));
+            }
+            None
+        }))
         .collect();
     println!("Total files: {}", &total_files);
     println!("Total used files: {}", (total_files - unused_files.len()));

--- a/src/unused_finder/node_visitor.rs
+++ b/src/unused_finder/node_visitor.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Display,
     iter::FromIterator,
-    sync::Arc, fmt::Display,
+    sync::Arc,
 };
 
 use swc_core::{

--- a/src/unused_finder/node_visitor.rs
+++ b/src/unused_finder/node_visitor.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     iter::FromIterator,
-    sync::Arc,
+    sync::Arc, fmt::Display,
 };
 
 use swc_core::{
@@ -42,6 +42,17 @@ pub enum ExportKind {
     Default,
     Namespace,
     ExecutionOnly, // in case of `import './foo';` this executes code in file but imports nothing
+}
+
+impl Display for ExportKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportKind::Named(name) => write!(f, "{}", name),
+            ExportKind::Default => write!(f, "default"),
+            ExportKind::Namespace => write!(f, "*"),
+            ExportKind::ExecutionOnly => write!(f, "import '<path>'"),
+        }
+    }
 }
 
 impl Default for ExportKind {


### PR DESCRIPTION
- Added feature to track unused items within used files.
  - When building report now filter used files and pull the ones that have non-empty list inside `GraphFile::unused_items`.
- Added capability to track items masked through `export ... from ...` statements.
  - Resolve/Mark items as used inside `GraphFile` now return an enum if the item was created in the file or it was pulled via export/from statement.