### PR TITLE
Add allow unused file comment feature

### DIFF
--- a/change/@good-fences-api-1bc7e62e-1e94-41ee-8dfd-720c4d05d496.json
+++ b/change/@good-fences-api-1bc7e62e-1e94-41ee-8dfd-720c4d05d496.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added feature to not mark files starting with `@allow-unused-file` as unused",
+  "packageName": "@good-fences/api",
+  "email": "edgar21_9@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -195,7 +195,12 @@ pub fn find_unused_items(
         }
     }
 
-    let unused_files = BTreeMap::from_iter(graph.files.drain().filter(|f| !f.1.is_used));
+    let unused_files = BTreeMap::from_iter(
+        graph
+            .files
+            .drain()
+            .filter(|f| !f.1.is_used && !f.1.import_export_info.allow_unused),
+    );
     let results: Vec<String> = unused_files
         .iter()
         .map(|f| format!("\"{}\",", f.0))

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -204,6 +204,10 @@ pub fn find_unused_items(
         .iter()
         .map(|f| format!("\"{}\",", f.0))
         .chain(graph.files.iter().filter_map(|(path, file)| {
+            // shortcircuit to not report unused items on files with `@allow-unused-file` comment
+            if file.import_export_info.allow_unused {
+                return None;
+            }
             let items = file
                 .unused_exports
                 .iter()

--- a/src/unused_finder/unused_finder_visitor_runner.rs
+++ b/src/unused_finder/unused_finder_visitor_runner.rs
@@ -116,10 +116,12 @@ pub fn get_import_export_paths_map(
         visit_module(&mut visitor, &resolved);
     });
 
-    let (leading,_) = comments.take_all();
+    let (leading, _) = comments.take_all();
     let comments = leading.borrow();
     let allow_unused = if let Some((_, comments)) = comments.iter().next() {
-        comments.iter().any(|c| c.text.to_string().trim() == "@allow-unused-file")
+        comments
+            .iter()
+            .any(|c| c.text.to_string().trim() == "@allow-unused-file")
     } else {
         false
     };
@@ -147,7 +149,6 @@ mod test {
     use std::sync::Arc;
 
     use super::get_import_export_paths_map;
-
 
     #[test]
     fn test_allow_unused_file_comment() {

--- a/tests/comments_panel_test/packages/accelerator/accelerator-common/src/CommentsPanel/index.ts
+++ b/tests/comments_panel_test/packages/accelerator/accelerator-common/src/CommentsPanel/index.ts
@@ -1,0 +1,8 @@
+// @allow-unused-file
+// here are some other comments :D
+/**
+ * also here
+ */
+// and here
+console.log("something")
+/* and also here */


### PR DESCRIPTION
Changes:
- Added feature to not report as unused files starting with `// @allow-unused-file` comment.
- Files starting with `// @allow-unused-file`  will be also excluded from unused item-specific report.