### PR TITLE
Added report struct to improve error handling in owa-build

### DIFF
--- a/change/@good-fences-api-8b2d7eb8-f54f-4f32-90d5-875daec6ee55.json
+++ b/change/@good-fences-api-8b2d7eb8-f54f-4f32-90d5-875daec6ee55.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added report struct to improve error handling in owa-build",
+  "packageName": "@good-fences/api",
+  "email": "edgar21_9@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use error::EvaluateFencesError;
 use napi::bindgen_prelude::ToNapiValue;
 use napi_derive::napi;
 use serde::Serialize;
-use unused_finder::FindUnusedItemsConfig;
+use unused_finder::{FindUnusedItemsConfig, UnusedFinderReport};
 use walk_dirs::ExternalFences;
 pub mod error;
 pub mod evaluate_fences;
@@ -190,7 +190,7 @@ pub struct JsonErrorFile<'a> {
  */
 
 #[napi]
-pub fn find_unused_items(config: FindUnusedItemsConfig) -> napi::Result<Vec<String>> {
+pub fn find_unused_items(config: FindUnusedItemsConfig) -> napi::Result<UnusedFinderReport> {
     match unused_finder::find_unused_items(config) {
         Ok(ok) => return Ok(ok),
         Err(e) => return Err(napi::Error::new(e.status, e.message)),


### PR DESCRIPTION
Created `UnusedFinderReport` struct:
- Instead of returning a `Vec<String>` that represents all error messages thrown during execution, now return `UnusedFinderReport`
  - `UnusedFinderReport::unused_files` a vec of files marked as unused, this list is already sanitized and does not contain non-scanned files or files that match any patter in `.unusedignore` file.
  - `UnusedFinderReport::unused_files_items` hashmap with **_key: file path_** and **_value: items within file that are not imported_**.