### PR TITLE
Added capabilities to find files and items only used in test files

### DIFF
--- a/change/@good-fences-api-ddd30c03-7ae0-4574-872f-92a414225bad.json
+++ b/change/@good-fences-api-ddd30c03-7ae0-4574-872f-92a414225bad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Find files only used in tests",
+  "packageName": "@good-fences/api",
+  "email": "edgar21_9@hotmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/unused_finder/graph.rs
+++ b/src/unused_finder/graph.rs
@@ -19,6 +19,7 @@ pub enum MarkItemResult {
 #[derive(Debug, Clone, Default)]
 pub struct GraphFile {
     pub is_used: bool,
+    pub is_test_file: bool,
     // pub package_name: String,
     pub file_path: String,
     pub unused_exports: HashSet<ExportKind>,
@@ -33,6 +34,7 @@ impl GraphFile {
         unused_exports: HashSet<ExportKind>,
         import_export_info: ImportExportInfo,
         is_used: bool,
+        is_test_file: bool,
     ) -> Self {
         let mut export_from = HashMap::new();
         import_export_info
@@ -49,6 +51,7 @@ impl GraphFile {
             file_path,
             unused_exports,
             import_export_info,
+            is_test_file,
         }
     }
 

--- a/src/unused_finder/graph.rs
+++ b/src/unused_finder/graph.rs
@@ -23,10 +23,8 @@ pub struct GraphFile {
     // pub package_name: String,
     pub file_path: String,
     pub unused_exports: HashSet<ExportKind>,
-    //
     pub export_from: HashMap<ExportKind, String>,
     pub import_export_info: ImportExportInfo,
-    pub only_used_in_test: HashSet<ExportKind>,
 }
 
 impl GraphFile {
@@ -35,7 +33,6 @@ impl GraphFile {
         unused_exports: HashSet<ExportKind>,
         import_export_info: ImportExportInfo,
         is_used: bool,
-        is_test_file: bool,
     ) -> Self {
         let mut export_from = HashMap::new();
         import_export_info
@@ -52,7 +49,6 @@ impl GraphFile {
             file_path,
             unused_exports,
             import_export_info,
-            is_test_file,
             ..Default::default()
         }
     }
@@ -76,12 +72,6 @@ impl GraphFile {
             return MarkItemResult::ResolveExportFrom(from.clone());
         }
         MarkItemResult::AlreadyMarked
-    }
-
-    pub fn mark_item_as_used_in_test(&mut self, item: &ExportKind) {
-        if let Some(taken) = self.unused_exports.take(item) {
-            self.only_used_in_test.insert(taken);
-        }
     }
 }
 

--- a/src/unused_finder/graph.rs
+++ b/src/unused_finder/graph.rs
@@ -26,6 +26,7 @@ pub struct GraphFile {
     //
     pub export_from: HashMap<ExportKind, String>,
     pub import_export_info: ImportExportInfo,
+    pub only_used_in_test: HashSet<ExportKind>,
 }
 
 impl GraphFile {
@@ -52,6 +53,7 @@ impl GraphFile {
             unused_exports,
             import_export_info,
             is_test_file,
+            ..Default::default()
         }
     }
 
@@ -74,6 +76,12 @@ impl GraphFile {
             return MarkItemResult::ResolveExportFrom(from.clone());
         }
         MarkItemResult::AlreadyMarked
+    }
+
+    pub fn mark_item_as_used_in_test(&mut self, item: &ExportKind) {
+        if let Some(taken) = self.unused_exports.take(item) {
+            self.only_used_in_test.insert(taken);
+        }
     }
 }
 

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -40,6 +40,7 @@ pub struct WalkFileMetaData {
     pub package_name: String,
     pub source_file_path: String,
     pub import_export_info: ImportExportInfo,
+    pub is_test_file: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -72,7 +73,7 @@ pub struct FindUnusedItemsConfig {
     pub entry_packages: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[napi(object)]
 pub struct ExportedItemReport {
     pub id: String,
@@ -85,6 +86,8 @@ pub struct ExportedItemReport {
 pub struct UnusedFinderReport {
     pub unused_files: Vec<String>,
     pub unused_files_items: HashMap<String, Vec<ExportedItemReport>>,
+    pub test_only_used_files: Vec<String>,
+    pub test_only_used_items: HashMap<String, Vec<ExportedItemReport>>,
     // pub flattened_walk_file_data: Vec<WalkFileMetaData>,
 }
 
@@ -224,6 +227,7 @@ pub fn find_unused_items(
                     .collect(),
                 file.import_export_info.clone(),
                 entry_packages.contains(&file.package_name), // mark files from entry_packages as used
+                file.is_test_file,
             )
         })
         .collect();
@@ -304,6 +308,7 @@ pub fn find_unused_items(
             .map(|(p, _)| p.to_string())
             .collect(),
         unused_files_items,
+        ..Default::default()
     })
 }
 

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -336,7 +336,7 @@ fn read_allow_list() -> Vec<glob::Pattern> {
 
 #[napi(js_name = "UnusedFinder")]
 pub struct UnusedFinderJs {
-    unused_finder: UnusedFinder
+    unused_finder: UnusedFinder,
 }
 
 #[napi]
@@ -344,10 +344,8 @@ impl UnusedFinderJs {
     #[napi(constructor)]
     pub fn new(config: FindUnusedItemsConfig) -> napi::Result<Self> {
         match UnusedFinder::new(config) {
-            Ok(unused_finder) => Ok(UnusedFinderJs {
-                unused_finder
-            }),
-            Err(e) => Err(e)
+            Ok(unused_finder) => Ok(UnusedFinderJs { unused_finder }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -35,6 +35,8 @@ use crate::{
     },
 };
 
+use self::unused_finder::UnusedFinder;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct WalkFileMetaData {
     pub package_name: String,
@@ -330,6 +332,31 @@ fn read_allow_list() -> Vec<glob::Pattern> {
         Err(_) => {}
     }
     vec![]
+}
+
+#[napi(js_name = "UnusedFinder")]
+pub struct UnusedFinderJs {
+    unused_finder: UnusedFinder
+}
+
+#[napi]
+impl UnusedFinderJs {
+    #[napi(constructor)]
+    pub fn new(config: FindUnusedItemsConfig) -> napi::Result<Self> {
+        match UnusedFinder::new(config) {
+            Ok(unused_finder) => Ok(UnusedFinderJs {
+                unused_finder
+            }),
+            Err(e) => Err(e)
+        }
+    }
+
+    pub fn find_unused_items(
+        &mut self,
+        files_to_check: Vec<String>,
+    ) -> napi::Result<UnusedFinderReport> {
+        self.unused_finder.find_unused_items(files_to_check)
+    }
 }
 
 fn process_import_export_info(

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -231,7 +231,6 @@ pub fn find_unused_items(
                     .collect(),
                 file.import_export_info.clone(),
                 entry_packages.contains(&file.package_name), // mark files from entry_packages as used
-                file.is_test_file,
             )
         })
         .collect();

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -29,8 +29,8 @@ use crate::{
         graph::{Graph, GraphFile},
         unused_finder_visitor_runner::ImportExportInfo,
         utils::{
-            process_async_imported_paths, process_executed_paths, process_exports_from,
-            process_import_path_ids, process_require_paths, retrieve_files,
+            process_exports_from_paths, resolve_async_imported_paths, resolve_executed_paths,
+            resolve_import_item_from_paths, resolve_require_paths, retrieve_files,
         },
     },
 };
@@ -217,7 +217,7 @@ pub fn find_unused_items(
     let mut files: Vec<GraphFile> = flattened_walk_file_data
         .par_iter_mut()
         .map(|file| {
-            process_import_export_info(
+            resolve_paths_from_import_export_info(
                 &mut file.import_export_info,
                 &file.source_file_path,
                 &resolver,
@@ -359,16 +359,16 @@ impl UnusedFinderJs {
     }
 }
 
-fn process_import_export_info(
+fn resolve_paths_from_import_export_info(
     f: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,
 ) {
-    process_executed_paths(f, source_file_path, resolver);
-    process_async_imported_paths(f, source_file_path, resolver);
-    process_exports_from(f, source_file_path, resolver);
-    process_require_paths(f, source_file_path, resolver);
-    process_import_path_ids(f, source_file_path, resolver);
+    resolve_executed_paths(f, source_file_path, resolver);
+    resolve_async_imported_paths(f, source_file_path, resolver);
+    process_exports_from_paths(f, source_file_path, resolver);
+    resolve_require_paths(f, source_file_path, resolver);
+    resolve_import_item_from_paths(f, source_file_path, resolver);
 }
 
 #[cfg(test)]

--- a/src/unused_finder/mod.rs
+++ b/src/unused_finder/mod.rs
@@ -349,6 +349,7 @@ impl UnusedFinderJs {
         }
     }
 
+    #[napi]
     pub fn find_unused_items(
         &mut self,
         files_to_check: Vec<String>,

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -83,7 +83,7 @@ impl UnusedFinder {
         };
         let skipped_items = Arc::new(skipped_items);
         let all_files =
-            retrieve_and_process_files(&paths_to_read, &skipped_dirs, &skipped_items, &resolver);
+            retrieve_files_and_resolve_import_paths(&paths_to_read, &skipped_dirs, &skipped_items, &resolver);
 
         let file_path_exported_items_map =
             create_report_map_from_flattened_files(&all_files, &entry_packages);
@@ -102,7 +102,7 @@ impl UnusedFinder {
     // Read and parse all files from disk have a fresh in-memory representation of self.entry_files and self.graph information
     pub fn refresh_all_files(&mut self) {
         // Get a vector with all WalkFileMetaData
-        let all_files = retrieve_and_process_files(
+        let all_files = retrieve_files_and_resolve_import_paths(
             &self.paths_to_read,
             &self.skipped_dirs,
             &self.skipped_items,
@@ -339,7 +339,7 @@ fn create_graph(source_files: &Vec<WalkFileMetaData>, entry_packages: &HashSet<S
     graph
 }
 
-fn retrieve_and_process_files(
+fn retrieve_files_and_resolve_import_paths(
     paths_to_read: &Vec<String>,
     skipped_dirs: &Arc<Vec<glob::Pattern>>,
     skipped_items: &Arc<Vec<regex::Regex>>,

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -36,7 +36,6 @@ pub struct UnusedFinder {
     resolver: Option<CachingResolver<TsConfigResolver<NodeModulesResolver>>>,
 }
 
-
 impl UnusedFinder {
     pub fn new(config: FindUnusedItemsConfig) -> napi::Result<Self> {
         let FindUnusedItemsConfig {
@@ -114,7 +113,6 @@ impl UnusedFinder {
     }
 
     // Read and parse all files from disk have a fresh in-memory representation of self.entry_files and self.graph information
-    
     pub fn refresh_all_files(&mut self) {
         // Get a vector with all WalkFileMetaData
         let all_files = retrieve_and_process_files(
@@ -156,7 +154,6 @@ impl UnusedFinder {
         self.test_files = test_files;
     }
 
-    
     pub fn find_unused_items(
         &mut self,
         files_to_check: Vec<String>,
@@ -181,15 +178,15 @@ impl UnusedFinder {
         // Create binding to entry_packages to avoid borrow checker complain about borrowing `self`
         let entry_packages = &self.entry_packages;
         let entry_pkgs_files: Vec<String> = self
-        .src_files
-        .par_iter_mut()
-        .filter_map(|file| {
-            if entry_packages.contains(&file.package_name) {
-                return Some(file.source_file_path.clone());
-            }
-            None
-        })
-        .collect();
+            .src_files
+            .par_iter_mut()
+            .filter_map(|file| {
+                if entry_packages.contains(&file.package_name) {
+                    return Some(file.source_file_path.clone());
+                }
+                None
+            })
+            .collect();
         let mut frontier = entry_pkgs_files.clone();
         for _ in 0..10_000_000 {
             frontier = graph.bfs_step(frontier);
@@ -209,7 +206,6 @@ impl UnusedFinder {
         let reported_unused_files = BTreeMap::from_iter(graph.files.iter().filter(|f| {
             !f.1.is_test_file && !f.1.is_used && !allow_list.iter().any(|p| p.matches(f.0))
         }));
-
 
         // Create Vec containing the string paths of source_files + test_files
         let all_files: Vec<_> = self

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -161,7 +161,7 @@ impl UnusedFinder {
                 None
             })
             .collect();
-        let mut frontier = entry_pkgs_files.clone();
+        let mut frontier = entry_pkgs_files;
         // Do graph bfs for entry package files
         for _ in 0..10_000_000 {
             frontier = graph.bfs_step(frontier);

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -226,10 +226,8 @@ impl UnusedFinder {
             .collect();
 
         unused_items.iter_mut().for_each(|(file, items)| {
-            match graph.files.get_mut(file) {
+            match graph.files.get(file) {
                 Some(graph_file) => {
-                    // Get interior mutable object reference
-                    let graph_file = Arc::get_mut(graph_file).unwrap();
                     // Iterate over each unused item from entry files
                     for item in items.iter_mut() {
                         // If the item is no longer in the list of unused items of graph_file, it was used only by test files

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -373,7 +373,6 @@ fn create_graph_files(
                     .collect(),
                 file.import_export_info.clone(),
                 entry_packages.contains(&file.package_name) || file.is_test_file, // mark files from entry_packages as used
-                file.is_test_file,
             )
         })
         .collect();

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -273,7 +273,7 @@ impl UnusedFinder {
                 .iter()
                 .map(|(p, _)| p.to_string())
                 .collect(),
-            unused_files_items: test_unused_items,
+            unused_files_items: unused_items,
             test_only_used_files,
             test_only_used_items,
         };

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -82,8 +82,12 @@ impl UnusedFinder {
             }
         };
         let skipped_items = Arc::new(skipped_items);
-        let all_files =
-            retrieve_files_and_resolve_import_paths(&paths_to_read, &skipped_dirs, &skipped_items, &resolver);
+        let all_files = retrieve_files_and_resolve_import_paths(
+            &paths_to_read,
+            &skipped_dirs,
+            &skipped_items,
+            &resolver,
+        );
 
         let file_path_exported_items_map =
             create_report_map_from_flattened_files(&all_files, &entry_packages);

--- a/src/unused_finder/unused_finder.rs
+++ b/src/unused_finder/unused_finder.rs
@@ -15,7 +15,7 @@ use crate::import_resolver::TsconfigPathsJson;
 use super::{
     create_caching_resolver, create_flattened_walked_files, create_report_map_from_flattened_files,
     graph::{Graph, GraphFile},
-    process_import_export_info, read_allow_list,
+    read_allow_list, resolve_paths_from_import_export_info,
     unused_finder_visitor_runner::get_import_export_paths_map,
     ExportedItemReport, FindUnusedItemsConfig, UnusedFinderReport, WalkFileMetaData,
 };
@@ -279,7 +279,7 @@ impl UnusedFinder {
                         let current_graph_file = Arc::get_mut(current_graph_file).unwrap();
                         current_graph_file.import_export_info = ok; // Update import_export_info within self.graph
                         self.logs.push(format!("refreshing {}", f.to_string()));
-                        process_import_export_info(
+                        resolve_paths_from_import_export_info(
                             // Process import/export info to use resolver.
                             &mut current_graph_file.import_export_info,
                             &f,
@@ -348,7 +348,7 @@ fn retrieve_and_process_files(
     let mut all_files = create_flattened_walked_files(&paths_to_read, skipped_dirs, skipped_items);
 
     all_files.par_iter_mut().for_each(|file| {
-        process_import_export_info(
+        resolve_paths_from_import_export_info(
             &mut file.import_export_info,
             &file.source_file_path,
             resolver,

--- a/src/unused_finder/utils.rs
+++ b/src/unused_finder/utils.rs
@@ -30,7 +30,7 @@ impl From<ExportKind> for ResolvedItem {
 }
 
 // import foo, {bar as something} from './foo'`
-pub fn process_import_path_ids(
+pub fn resolve_import_item_from_paths(
     import_export_info: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,
@@ -58,7 +58,7 @@ pub fn process_import_path_ids(
 }
 
 // `export {default as foo, bar} from './foo'`
-pub fn process_exports_from(
+pub fn process_exports_from_paths(
     import_export_info: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,
@@ -89,7 +89,7 @@ pub fn process_exports_from(
 }
 
 // import('./foo')
-pub fn process_async_imported_paths(
+pub fn resolve_async_imported_paths(
     import_export_info: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,
@@ -118,7 +118,7 @@ pub fn process_async_imported_paths(
 }
 
 // import './foo'
-pub fn process_executed_paths(
+pub fn resolve_executed_paths(
     import_export_info: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,
@@ -148,7 +148,7 @@ pub fn process_executed_paths(
 }
 
 // require('foo')
-pub fn process_require_paths(
+pub fn resolve_require_paths(
     import_export_info: &mut ImportExportInfo,
     source_file_path: &String,
     resolver: &dyn Resolve,

--- a/src/unused_finder/utils.rs
+++ b/src/unused_finder/utils.rs
@@ -181,6 +181,7 @@ pub fn retrieve_files(
     skipped_dirs: Option<Vec<glob::Pattern>>,
     skipped_items: Arc<Vec<regex::Regex>>,
 ) -> Vec<WalkedFile> {
+    let test_pattern = glob::Pattern::new("**/test/**").unwrap();
     let walk_dir = WalkDirGeneric::<(String, WalkedFile)>::new(start_path).process_read_dir(
         move |dir_state, children| {
             children.iter_mut().for_each(|dir_entry_res| {
@@ -235,6 +236,7 @@ pub fn retrieve_files(
                                     Ok(import_export_info) => {
                                         dir_entry.client_state =
                                             WalkedFile::SourceFile(WalkFileMetaData {
+                                                is_test_file: test_pattern.matches(&slashed),
                                                 package_name: dir_state.clone(),
                                                 import_export_info,
                                                 source_file_path: dir_entry

--- a/unused.js
+++ b/unused.js
@@ -1,41 +1,6 @@
 #! /usr/bin/env node
 let unused = require("./index").findUnusedItems;
 
-const entry = [
-  "**/owa-calendar-deeplink-opx-bootstrap/**",
-  "**/owa-publishedcalendar-bootstrap/**",
-  "**/owa-mail-bootstrap/**",
-  "**/owa-deeplink-bootstrap/**",
-  "**/owa-mail-deeplink-opx-bootstrap/**",
-  "**/meet-bootstrap/**",
-  "**/owa-message-recall/**",
-  "**/native-host-bootstrap/**",
-  "**/native-host-deep-bootstrap/**",
-  "**/owa-tokenprovider/**",
-  "**/owa-bookings-bootstrap/**",
-  "**/owa-bookingsv2-bootstrap/**",
-  "**/owa-bookings-mobile-bootstrap/**",
-  "**/owa-bookings-c2-bootstrap/**",
-  "**/owa-serviceworker-v2/**",
-  "**/owa-webpush-serviceworker/**",
-  "**/owa-findtime-bootstrap/**",
-  "**/owa-jit-experience/**",
-  "**/eventify-bootstrap/**",
-  "**/owa-opx-app-bootstrap/**",
-  "**/owa-safelink-waitingpage/**",
-  "**/owa-calendar-widget/**",
-  "**/owa-todo-widget/**",
-  "**/bookwithme-bootstrap/**",
-  "**/owa-ads-frame/**",
-  "**/owa-adbar-frame/**",
-  "**/owa-fluent-icons-svg/App/**",
-  "**/oobe-bootstrap/**",
-  "**/addison-bootstrap/**",
-  "**/places-bootstrap/**",
-  "**/owa-immersive-bizchat-bootstrap/**",
-  "**/owa-immersive-bizchat-bootstrap/**",
-];
-
 const entries = [
   "owa-addins-osfruntime-resources",
   "owa-analytics",
@@ -105,7 +70,7 @@ const config = {
   tsConfigPath: "./tsconfig.paths.json",
 };
 
-// let report = new UnusedFinder(config).findUnusedItems([]);
-let report = unused(config);
+let report = new UnusedFinder(config).findUnusedItems([]);
+// let report = unused(config);
 // console.log(report);
 console.log(report.unusedFilesItems);

--- a/unused.js
+++ b/unused.js
@@ -73,4 +73,4 @@ const config = {
 let report = new UnusedFinder(config).findUnusedItems([]);
 // let report = unused(config);
 // console.log(report);
-console.log(report.unusedFilesItems);
+console.log(report.testOnlyUsedFiles);

--- a/unused.js
+++ b/unused.js
@@ -83,9 +83,10 @@ const entries = [
   "sample-query-field-policy",
 ];
 
+const { UnusedFinder } = require("./index");
 const workers = require("/workspaces/client-web/workers.glob.json");
 
-let report = unused({
+const config = {
   entryPackages: entries,
   filesIgnoredExports: [],
   filesIgnoredImports: [],
@@ -94,10 +95,7 @@ let report = unused({
     // ...workers.files,
     // ...workers.excludedFiles,
     "**/osfruntime_strings.js",
-    "**/test/**",
     "**/scripts/**",
-    "**/*.Test.ts",
-    "**/*.Tests.ts",
     "**/*.d.ts",
     "**/*.d.scss.ts",
     "**/*.d.json.ts",
@@ -105,5 +103,8 @@ let report = unused({
   ],
   skippedItems: [],
   tsConfigPath: "./tsconfig.paths.json",
-});
+};
+
+let report = new UnusedFinder(config).findUnusedItems([]);
+// let report = unused(config);
 console.log(report);

--- a/unused.js
+++ b/unused.js
@@ -105,6 +105,7 @@ const config = {
   tsConfigPath: "./tsconfig.paths.json",
 };
 
-let report = new UnusedFinder(config).findUnusedItems([]);
-// let report = unused(config);
-console.log(report);
+// let report = new UnusedFinder(config).findUnusedItems([]);
+let report = unused(config);
+// console.log(report);
+console.log(report.unusedFilesItems);


### PR DESCRIPTION
Find files only used only used/reachable from test files:
- Added `is_test_file` property to `WalkFileMetadata` struct, generated during filewalk. Set to `true` if file matches pattern `**/test/**`.
- Added property `test_only_use` to `ExportedItemReport` to identify items only imported by test files.
- Added a second bfs walk on graph
  - First walk uses files from entry packages as initial frontier, generates the list and map of files not reachable and never-imported items.
  - Second walk uses test files as initial frontier.
  - After second walk we make a `diff` like processing, where we check for which files and items were initially marked as unused (not reachable by entry packages) and a second check (files and items marked as used after BFS on test files) to identify what is used only in tests.