### PR TITLE
Reverted good-fences resolver function to enable run quick checks on local environments

### DIFF
--- a/change/@good-fences-api-0e4ef024-a32b-4faa-a002-c007116eb92a.json
+++ b/change/@good-fences-api-0e4ef024-a32b-4faa-a002-c007116eb92a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Reverted good-fences resolver function to enable run quick checks on local environments",
+  "packageName": "@good-fences/api",
+  "email": "edgarivanv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/good-fences.js
+++ b/good-fences.js
@@ -35,7 +35,7 @@ result.forEach(r => {
     }
 
     if (r.resultType === GoodFencesResultType.Violation) {
-        console.error(r.detailedMessage);
+        // console.error(r.detailedMessage);
     }
 });
 

--- a/good-fences.js
+++ b/good-fences.js
@@ -35,7 +35,7 @@ result.forEach(r => {
     }
 
     if (r.resultType === GoodFencesResultType.Violation) {
-        // console.error(r.detailedMessage);
+        console.error(r.detailedMessage);
     }
 });
 

--- a/src/evaluate_fences.rs
+++ b/src/evaluate_fences.rs
@@ -172,7 +172,6 @@ pub fn evaluate_fences<'fencecollectionlifetime, 'sourcefilelifetime>(
     let source_fences_set: HashSet<&Fence> = HashSet::from_iter(source_fences);
 
     for (import_specifier, _imported_names) in source_file.imports.iter() {
-        
         let importer_rel_path = RelativePath::from_path(&source_file.source_file_path).unwrap();
         let resolved_src_import =
             resolve_ts_import(tsconfig_paths_json, importer_rel_path, &import_specifier);

--- a/src/import_resolver.rs
+++ b/src/import_resolver.rs
@@ -53,7 +53,7 @@ pub enum ResolvedImport {
     ResourceFileImport,
 }
 
-const SOURCE_EXTENSIONS: &[&str] = &["js", "ts", "d.ts", "tsx", "jsx"];
+pub const SOURCE_EXTENSIONS: &[&str] = &["js", "ts", "d.ts", "tsx", "jsx"];
 pub const ASSET_EXTENSION: &[&str] = &["scss", "css", "svg", "png", "json", "gif"];
 
 pub fn resolve_with_extension(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,8 @@ pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesResult> {
             eval_results.violations,
             eval_results.unresolved_files,
             output,
-        );
+        )
+        .unwrap();
     }
 
     errors

--- a/src/walk_dirs.rs
+++ b/src/walk_dirs.rs
@@ -62,6 +62,13 @@ pub fn discover_fences_and_files(
 ) -> Vec<WalkFileData> {
     let walk_dir = WalkDirGeneric::<(TagList, WalkFileData)>::new(start_path).process_read_dir(
         move |read_dir_state, children| {
+            children.iter_mut().for_each(|child| {
+                if let Ok(dir_entry) = child {
+                    if dir_entry.file_name() == "node_modules" || dir_entry.file_name() == "lib" {
+                        dir_entry.read_children_path = None;
+                    }
+                }
+            });
             // Custom filter -- retain only directories and fence.json files
             children.retain(|dir_entry_result| {
                 match dir_entry_result {


### PR DESCRIPTION
Current SWC resolver prioritizes resolving paths to `**/lib/**` files instead of using tsconfig.paths.json `compilerOptions.paths` values. This prevents devs from running good-fences accurately if they run local builds or run `yarn typecheck` since those generate files under packages `lib/` dir.
Reverting to old resolver and adding some logic to handle cases such as adding extensions to files and appending `index` whenever is needed.
