### PR TITLE
add report_exported_items flag to gate reporting exported items

### DIFF
--- a/change/@good-fences-api-a651a4d8-d9c8-41de-a1f3-36fcfdb1edde.json
+++ b/change/@good-fences-api-a651a4d8-d9c8-41de-a1f3-36fcfdb1edde.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add report_exported_items flag to gate reporting exported items",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/unused_finder/src/unused_finder.rs
+++ b/crates/unused_finder/src/unused_finder.rs
@@ -37,6 +37,7 @@ pub struct UnusedFinder {
 impl UnusedFinder {
     pub fn new(config: FindUnusedItemsConfig) -> anyhow::Result<Self, JsErr> {
         let FindUnusedItemsConfig {
+            report_exported_items: _,
             paths_to_read,
             ts_config_path,
             skipped_dirs,


### PR DESCRIPTION
Disable per-item reporting with report_exported_items flag

This is for cleaner test reporting while debugging unused files in `unused_bin`