### PR TITLE
pacakgejson, import_resolver: heterogenous export maps

### DIFF
--- a/change/@good-fences-api-f5109c05-4f36-4f15-8742-fb295865c36d.json
+++ b/change/@good-fences-api-f5109c05-4f36-4f15-8742-fb295865c36d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "support heterogenous export maps in packagejson files",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/import_resolver/src/swc_resolver/pkgjson_exports.rs
+++ b/crates/import_resolver/src/swc_resolver/pkgjson_exports.rs
@@ -325,7 +325,7 @@ impl TryFrom<&PackageJsonExports> for PackageExportRewriteData {
             }
 
             // for simple exports, simulate a conditional exports map with a single entry, "default"
-            // This will be conditionally stored on the stack here, in my_cond_exp while it is being used.
+            // If needed, store it on the stack in my_cond_exp, allowing conditional_exports to be a reference type
             let my_cond_exp: AHashMap<String, ExportedPath>;
             let conditional_exports = match exported {
                 PackageJsonExport::Single(export_target) => {

--- a/crates/import_resolver/src/swc_resolver/pkgjson_exports.rs
+++ b/crates/import_resolver/src/swc_resolver/pkgjson_exports.rs
@@ -8,8 +8,10 @@ use path_slash::PathBufExt;
 
 use packagejson::{
     exported_path::{ExportedPath, ExportedPathRef},
-    PackageJsonExports,
+    PackageJsonExport, PackageJsonExports,
 };
+
+use super::common::AHashMap;
 
 // Pair path, export-condfition of form ('package-name/imported-path', 'import')
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -314,86 +316,73 @@ impl TryFrom<&PackageJsonExports> for PackageExportRewriteData {
     type Error = anyhow::Error;
 
     fn try_from(exports_map: &PackageJsonExports) -> Result<Self> {
-        match exports_map {
-            PackageJsonExports::Single(exports_map) => {
-                // this is a simple export map of form
-                // { "exports": { "import": "./index.ejs", "require": "./index.cjs" } }
-                // with no sub-path exports
-                //
-                // This is equivlaent to a an export map with a single path entry of "."
-
-                let static_exports = exports_map
-                    .iter()
-                    .map(
-                        |(export_kind, export_target)| -> (ExportKey, Option<String>) {
-                            (
-                                ExportKey(".".to_string(), export_kind.clone()),
-                                export_target.as_ref().map(|e| clean_path(e)),
-                            )
-                        },
-                    )
-                    .map(|(key, target)| (key, target.into()))
-                    .collect();
-
-                Ok(PackageExportRewriteData {
-                    static_exports,
-                    ..Default::default()
-                })
+        let mut resolution_data = PackageExportRewriteData::default();
+        for (export_path, exported) in exports_map.iter() {
+            if !export_path.starts_with("./") && export_path != "." {
+                return Err(anyhow!(
+                    "package.json exports fields must either be '.' or start with './'"
+                ));
             }
-            PackageJsonExports::Multiple(exports_map) => {
-                // Iterate through the exports map and build up the export resolution data
-                let mut resolution_data = PackageExportRewriteData::default();
-                for (export_path, conditional_exports) in exports_map.iter() {
-                    if !export_path.starts_with("./") && export_path != "." {
-                        return Err(anyhow!(
-                            "package.json exports fields must either be '.' or start with './'"
-                        ));
-                    }
 
-                    let export_path_star_ct = export_path.chars().filter(|c| *c == '*').count();
-                    if export_path_star_ct == 1 {
-                        // star pattern
-                        for (export_condition, export_target) in conditional_exports.iter() {
-                            resolution_data
-                                .star_exports
-                                .entry_ref(export_condition)
-                                .or_insert_with(Vec::new)
-                                .push((
-                                    clean_path(export_path),
-                                    export_target.map_export(clean_path),
-                                ));
-                        }
-                    } else if export_path_star_ct > 1 {
-                        return Err(anyhow!(
-                            "Invalid star pattern '{}' in package.json exports field: \
-                            Star patterns may contain at most a single star match.",
-                            export_path
-                        ));
-                    } else if export_path.ends_with('/') {
-                        // deprecated node 14.x directory pattern
-                        for (export_condition, export_target) in conditional_exports.iter() {
-                            resolution_data
-                                .star_exports
-                                .entry_ref(export_condition)
-                                .or_insert_with(Vec::new)
-                                .push((
-                                    clean_path(export_path),
-                                    export_target.map_export(clean_path),
-                                ));
-                        }
-                    } else {
-                        // literal export
-                        for (export_condition, export_target) in conditional_exports.iter() {
-                            resolution_data.static_exports.insert(
-                                ExportKey(clean_path(export_path), export_condition.clone()),
-                                export_target.map_export(clean_path),
-                            );
-                        }
-                    }
+            // for simple exports, simulate a conditional exports map with a single entry, "default"
+            // This will be conditionally stored on the stack here, in my_cond_exp while it is being used.
+            let my_cond_exp: AHashMap<String, ExportedPath>;
+            let conditional_exports = match exported {
+                PackageJsonExport::Single(export_target) => {
+                    let entry = (
+                        "default".to_string(),
+                        match export_target {
+                            Some(v) => ExportedPath::Exported(v.to_string()),
+                            None => ExportedPath::Private,
+                        },
+                    );
+                    my_cond_exp = AHashMap::from_iter(vec![entry].drain(..));
+                    &my_cond_exp
                 }
+                PackageJsonExport::Conditional(conditional_exports) => conditional_exports,
+            };
 
-                Ok(resolution_data)
+            let export_path_star_ct = export_path.chars().filter(|c| *c == '*').count();
+            if export_path_star_ct == 1 {
+                // star pattern
+                for (export_condition, export_target) in conditional_exports.iter() {
+                    resolution_data
+                        .star_exports
+                        .entry_ref(export_condition)
+                        .or_insert_with(Vec::new)
+                        .push((
+                            clean_path(export_path),
+                            export_target.map_export(clean_path),
+                        ));
+                }
+            } else if export_path_star_ct > 1 {
+                return Err(anyhow!(
+                    "Invalid star pattern '{}' in package.json exports field: \
+                            Star patterns may contain at most a single star match.",
+                    export_path
+                ));
+            } else if export_path.ends_with('/') {
+                // deprecated node 14.x directory pattern
+                for (export_condition, export_target) in conditional_exports.iter() {
+                    resolution_data
+                        .star_exports
+                        .entry_ref(export_condition)
+                        .or_insert_with(Vec::new)
+                        .push((
+                            clean_path(export_path),
+                            export_target.map_export(clean_path),
+                        ));
+                }
+            } else {
+                // literal export
+                for (export_condition, export_target) in conditional_exports.iter() {
+                    resolution_data.static_exports.insert(
+                        ExportKey(clean_path(export_path), export_condition.clone()),
+                        export_target.map_export(clean_path),
+                    );
+                }
             }
         }
+        Ok(resolution_data)
     }
 }

--- a/crates/packagejson/src/packagejson.rs
+++ b/crates/packagejson/src/packagejson.rs
@@ -5,7 +5,7 @@ use swc_common::collections::AHashMap;
 use crate::exported_path::ExportedPath;
 
 // Either a json string or a boolean
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum StringOrBool {
     Str(String),
@@ -13,7 +13,7 @@ pub enum StringOrBool {
 }
 
 // package.json .browser field
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Browser {
     Str(String),
@@ -23,7 +23,7 @@ pub enum Browser {
 pub type BrowserMap = AHashMap<String, StringOrBool>;
 
 // Subset of package.json used during file resolution
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct PackageJson {
     pub name: Option<String>,
     #[serde(default)]
@@ -36,9 +36,11 @@ pub struct PackageJson {
     pub exports: Option<PackageJsonExports>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+pub type PackageJsonExports = AHashMap<String, PackageJsonExport>;
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
-pub enum PackageJsonExports {
+pub enum PackageJsonExport {
     // An un-nested hashmap of that only maps the index of the module to the path
     //
     // e.g:
@@ -47,7 +49,7 @@ pub enum PackageJsonExports {
     //   "require": "./main.js"
     //   "default": "./main.js"
     // }
-    Single(AHashMap<String, Option<String>>),
+    Single(Option<String>),
     // A nested hashmap that maps multiple import paths into the module:
     //
     // e.g:
@@ -63,7 +65,7 @@ pub enum PackageJsonExports {
     //     "default": "./lib/util.js"
     //   }
     // }
-    Multiple(AHashMap<String, AHashMap<String, ExportedPath>>),
+    Conditional(AHashMap<String, ExportedPath>),
 }
 
 impl ContextData for PackageJson {


### PR DESCRIPTION
Support heterogenous export maps in import_resolver and package.json

This is an export map that mixes conditional and non-conditional exports e.g.:

```json5
{
  "exports": {
    // non-conditional export
    ".": "./src/index.js"

    //conditional export
    "./foo": {
      "import": "./src/foo.mjs"
      "require": "./src/foo.cjs"
      "default": "./src/foo.cjs"
    }
  }
}
```