### PR TITLE
import_resolver: add and expose `is_file_exported` for checking if a file is exported from a package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ dependencies = [
  "napi",
  "napi-derive",
  "packagejson",
+ "path-clean 0.1.0",
  "path-slash",
  "pretty_assertions",
  "rayon",

--- a/change/@good-fences-api-fe0720e5-9f97-4b22-a945-20bad35635de.json
+++ b/change/@good-fences-api-fe0720e5-9f97-4b22-a945-20bad35635de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add internal utility to check if a file is exported from a package",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/import_resolver/src/swc_resolver/mod.rs
+++ b/crates/import_resolver/src/swc_resolver/mod.rs
@@ -17,7 +17,7 @@ pub mod combined_resolver;
 mod common;
 pub mod internal_resolver;
 mod node_resolver;
-mod pkgjson_exports;
+pub mod pkgjson_exports;
 mod pkgjson_rewrites;
 mod tsconfig;
 mod tsconfig_resolver;

--- a/crates/test_tmpdir/src/lib.rs
+++ b/crates/test_tmpdir/src/lib.rs
@@ -27,6 +27,19 @@ macro_rules! map(
 );
 
 #[macro_export]
+macro_rules! map2(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+    };
+);
+
+#[macro_export]
 macro_rules! test_tmpdir(
     { $($key:expr => $value:expr),+ } => {
         {


### PR DESCRIPTION
Add utilities to import_resolver's packagejson_exports to support checking if a file is exported from a package.
    
This will be used by the unused_finder to determine if a file is an entrypoint to the graph walk when the package has an exports map.

In order to support tests, I also added a second map macro that does not stringify keys. This is because we want to create maps that have &'static str keys instead of String keys in the tests for is_file_exported