### PR TITLE
reduce compilation times by breaking up swc_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms",
  "swc_ecma_visit",
- "swc_utils",
+ "swc_utils_parse",
  "text-diff",
  "thiserror",
  "tsconfig_paths",
@@ -1140,6 +1140,17 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "normalize_src"
+version = "0.2.0"
+dependencies = [
+ "pretty_assertions",
+ "swc_common",
+ "swc_compiler_base",
+ "swc_ecma_ast",
+ "swc_utils_parse",
+]
 
 [[package]]
 name = "normpath"
@@ -2337,12 +2348,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_utils"
+name = "swc_utils_parse"
 version = "0.2.0"
 dependencies = [
  "pretty_assertions",
  "swc_common",
- "swc_compiler_base",
  "swc_ecma_ast",
  "swc_ecma_parser",
 ]
@@ -2656,7 +2666,6 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "rayon",
- "regex",
  "serde",
  "serde_json",
  "stringreader",
@@ -2666,7 +2675,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms",
  "swc_ecma_visit",
- "swc_utils",
+ "swc_utils_parse",
  "test_tmpdir",
  "thiserror",
  "tsconfig_paths",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,7 +2351,6 @@ dependencies = [
 name = "swc_utils_parse"
 version = "0.2.0"
 dependencies = [
- "pretty_assertions",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "1.0.52"
 # Build with debug info, but split it into separate pdb files we don't need to distribute
 debug = true
 split-debuginfo = "packed"
-# optimises for speed oveer size
+# optimises for speed over size
 opt-level = "s"
 # run link-time optimisation for release builds.
 # This will make the final binary take longer to build, but can result in faster, samller  code.

--- a/change/@good-fences-api-de8779f5-235e-410b-99b3-b8a562a72db7.json
+++ b/change/@good-fences-api-de8779f5-235e-410b-99b3-b8a562a72db7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "reduce compilation times by breaking up swc_utils",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/ahashmap/Cargo.toml
+++ b/crates/ahashmap/Cargo.toml
@@ -9,7 +9,7 @@ description = "A hashmap with ahash as the hasher"
 crate-type = ["lib"]
 
 [dependencies]
-ahash = { version = "0.8.11", optional = true }
+ahash = { version = "0.8.11", optional = true , default-features = false }
 
 [features]
 default = ["ahash"]

--- a/crates/good_fences/Cargo.toml
+++ b/crates/good_fences/Cargo.toml
@@ -34,5 +34,5 @@ swc_ecma_visit.workspace = true
 swc_ecma_transforms.workspace = true
 
 [dev-dependencies]
-swc_utils = { path = "../swc_utils" }
+swc_utils_parse = { path = "../swc_utils_parse" }
 text-diff = "0.4.0"

--- a/crates/good_fences/src/get_imports/import_path_visitor.rs
+++ b/crates/good_fences/src/get_imports/import_path_visitor.rs
@@ -165,7 +165,7 @@ mod test {
     use swc_ecma_transforms::resolver;
     use swc_ecma_visit::{FoldWith, VisitWith};
 
-    use swc_utils::parse_ecma_src;
+    use swc_utils_parse::parse_ecma_src;
 
     use super::ImportPathVisitor;
 

--- a/crates/swc_utils_parse/Cargo.toml
+++ b/crates/swc_utils_parse/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "swc_utils_parse"
+version = "0.2.0"
+authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+swc_common.workspace = true
+swc_ecma_parser.workspace = true
+swc_ecma_ast.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/crates/swc_utils_parse/Cargo.toml
+++ b/crates/swc_utils_parse/Cargo.toml
@@ -11,6 +11,3 @@ crate-type = ["lib"]
 swc_common.workspace = true
 swc_ecma_parser.workspace = true
 swc_ecma_ast.workspace = true
-
-[dev-dependencies]
-pretty_assertions.workspace = true

--- a/crates/swc_utils_parse/src/lib.rs
+++ b/crates/swc_utils_parse/src/lib.rs
@@ -1,0 +1,50 @@
+use swc_common::comments::Comments;
+use swc_common::sync::Lrc;
+use swc_common::{FileName, SourceFile, SourceMap};
+use swc_ecma_ast::Module;
+use swc_ecma_parser::{lexer::Lexer, StringInput, Syntax};
+use swc_ecma_parser::{Capturing, Parser, TsSyntax};
+
+pub fn create_lexer<'a>(fm: &'a SourceFile, comments: Option<&'a dyn Comments>) -> Lexer<'a> {
+    let filename = fm.name.to_string();
+    let lexer = Lexer::new(
+        Syntax::Typescript(TsSyntax {
+            tsx: filename.ends_with(".tsx") || filename.ends_with(".jsx"),
+            decorators: true,
+            ..Default::default()
+        }),
+        Default::default(),
+        StringInput::from(fm),
+        comments,
+    );
+    lexer
+}
+
+pub fn parse_ecma_src<TName, TBody>(name_str: TName, body: TBody) -> (Lrc<SourceMap>, Module)
+where
+    TName: Into<String>,
+    TBody: ToString,
+{
+    parse_ecma_src_comments(name_str, body, None)
+}
+
+pub fn parse_ecma_src_comments<TName, TBody>(
+    name_str: TName,
+    body: TBody,
+    comments: Option<&dyn Comments>,
+) -> (Lrc<SourceMap>, Module)
+where
+    TName: Into<String>,
+    TBody: ToString,
+{
+    let cm = Lrc::<SourceMap>::default();
+    let fname: Lrc<FileName> = Lrc::new(FileName::Custom(name_str.into()));
+    let fm = cm.new_source_file(fname, body.to_string());
+
+    let lexer: Lexer<'_> = create_lexer(&fm, comments);
+    let capturing = Capturing::new(lexer);
+    let mut parser: Parser<Capturing<Lexer<'_>>> = Parser::new_from(capturing);
+    let module = parser.parse_typescript_module().unwrap();
+
+    (cm, module)
+}

--- a/crates/swc_utils_print/Cargo.toml
+++ b/crates/swc_utils_print/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "swc_utils"
+name = "normalize_src"
 version = "0.2.0"
 authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
 edition = "2018"
@@ -9,9 +9,9 @@ crate-type = ["lib"]
 
 [dependencies]
 swc_common.workspace = true
-swc_ecma_parser.workspace = true
 swc_ecma_ast.workspace = true
 swc_compiler_base.workspace = true
+swc_utils_parse = { path = "../swc_utils_parse" }
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/swc_utils_print/src/lib.rs
+++ b/crates/swc_utils_print/src/lib.rs
@@ -1,54 +1,8 @@
 use swc_common::comments::{Comments, SingleThreadedComments};
 use swc_common::sync::Lrc;
-use swc_common::{FileName, SourceFile, SourceMap};
+use swc_common::SourceMap;
 use swc_compiler_base::PrintArgs;
 use swc_ecma_ast::Module;
-use swc_ecma_parser::{lexer::Lexer, StringInput, Syntax};
-use swc_ecma_parser::{Capturing, Parser, TsSyntax};
-
-pub fn create_lexer<'a>(fm: &'a SourceFile, comments: Option<&'a dyn Comments>) -> Lexer<'a> {
-    let filename = fm.name.to_string();
-    let lexer = Lexer::new(
-        Syntax::Typescript(TsSyntax {
-            tsx: filename.ends_with(".tsx") || filename.ends_with(".jsx"),
-            decorators: true,
-            ..Default::default()
-        }),
-        Default::default(),
-        StringInput::from(fm),
-        comments,
-    );
-    lexer
-}
-
-pub fn parse_ecma_src<TName, TBody>(name_str: TName, body: TBody) -> (Lrc<SourceMap>, Module)
-where
-    TName: Into<String>,
-    TBody: ToString,
-{
-    parse_ecma_src_comments(name_str, body, None)
-}
-
-pub fn parse_ecma_src_comments<TName, TBody>(
-    name_str: TName,
-    body: TBody,
-    comments: Option<&dyn Comments>,
-) -> (Lrc<SourceMap>, Module)
-where
-    TName: Into<String>,
-    TBody: ToString,
-{
-    let cm = Lrc::<SourceMap>::default();
-    let fname: Lrc<FileName> = Lrc::new(FileName::Custom(name_str.into()));
-    let fm = cm.new_source_file(fname, body.to_string());
-
-    let lexer: Lexer<'_> = create_lexer(&fm, comments);
-    let capturing = Capturing::new(lexer);
-    let mut parser: Parser<Capturing<Lexer<'_>>> = Parser::new_from(capturing);
-    let module = parser.parse_typescript_module().unwrap();
-
-    (cm, module)
-}
 
 pub fn ast_to_str(cm: &Lrc<SourceMap>, module: &Module, print_args: PrintArgs<'_>) -> String {
     let out_str = swc_compiler_base::print(cm.clone(), module, print_args).unwrap();
@@ -70,7 +24,7 @@ pub fn normalise_src(src: &str, print_args: PrintArgs) -> String {
         pargs.comments = own_comments.as_ref().map(|c| c as &dyn Comments);
     }
 
-    let (cm, parsed) = parse_ecma_src_comments("test.ts", src, pargs.comments);
+    let (cm, parsed) = swc_utils_parse::parse_ecma_src_comments("test.ts", src, pargs.comments);
     ast_to_str(&cm, &parsed, pargs)
 }
 

--- a/crates/unused_finder/Cargo.toml
+++ b/crates/unused_finder/Cargo.toml
@@ -15,7 +15,6 @@ import_resolver = { path = "../import_resolver" }
 js_err = { path = "../js_err" }
 path-slash.workspace = true
 rayon.workspace = true
-regex.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 swc_common.workspace = true
@@ -24,7 +23,7 @@ swc_ecma_loader.workspace = true
 swc_ecma_parser.workspace = true
 swc_ecma_visit.workspace = true
 swc_ecma_transforms.workspace = true
-swc_utils = { path = "../swc_utils" }
+swc_utils_parse = { path = "../swc_utils_parse" }
 thiserror.workspace = true
 tsconfig_paths = { path = "../tsconfig_paths" }
 packagejson = { path = "../packagejson" }

--- a/crates/unused_finder/src/parse/exports_visitor_runner.rs
+++ b/crates/unused_finder/src/parse/exports_visitor_runner.rs
@@ -9,7 +9,7 @@ use swc_ecma_parser::{Capturing, Parser};
 use swc_ecma_transforms::resolver;
 use swc_ecma_visit::{Fold, VisitWith};
 
-use swc_utils::create_lexer;
+use swc_utils_parse::create_lexer;
 
 use crate::parse::exports_visitor::ExportsVisitor;
 use crate::parse::RawImportExportInfo;

--- a/crates/unused_finder/src/parse/exports_visitor_tests.rs
+++ b/crates/unused_finder/src/parse/exports_visitor_tests.rs
@@ -9,7 +9,7 @@ mod test {
     use swc_ecma_visit::VisitWith;
 
     use crate::parse::{ExportedSymbol, ReExportedSymbol};
-    use swc_utils::create_lexer;
+    use swc_utils_parse::create_lexer;
 
     use crate::parse::exports_visitor::ExportsVisitor;
     use test_tmpdir::{amap, aset};


### PR DESCRIPTION
This saves between 0.5s and 1s on the end-to-end development compilation time (~25.7s ->~25.1s in my scratch testing)
This is because code normalization (not yet used) depends on the swc_ecma_minifier indirectly, which is slow to compile.