### PR TITLE
cancel old CI jobs when new PR revisions are pushed

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   workflow_call:
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   checks:
     strategy:

--- a/change/@good-fences-api-efc2f88d-514a-4a48-a185-63f4655d449d.json
+++ b/change/@good-fences-api-efc2f88d-514a-4a48-a185-63f4655d449d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "cancel old CI jobs when new PR revisions are pushed",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Neat trick I ran into on this blog:
https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions