### PR TITLE
unused finder: support type-only exports

### DIFF
--- a/change/@good-fences-api-144caee8-8d20-4404-9140-1c481de6e396.json
+++ b/change/@good-fences-api-144caee8-8d20-4404-9140-1c481de6e396.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "unused_finder: permit type-only exports",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/unused_finder/src/cfg/mod.rs
+++ b/crates/unused_finder/src/cfg/mod.rs
@@ -80,6 +80,11 @@ pub struct UnusedFinderJSONConfig {
     /// If true, individual exported symbols are also tracked
     #[serde(default)]
     pub report_exported_symbols: bool,
+    /// If true, type-only exports will not be reported as used.
+    /// However, the transitive dependencies of unused types will still be
+    /// reported as unused.
+    #[serde(default)]
+    pub allow_unused_types: bool,
     /// List of packages that should be considered "entry" packages
     /// All transitive imports from the exposed exports of these packages
     /// will be considered used
@@ -96,6 +101,10 @@ pub struct UnusedFinderJSONConfig {
 pub struct UnusedFinderConfig {
     /// If true, the finder should report exported symbols that are not used anywhere in the project
     pub report_exported_symbols: bool,
+    /// If true, type-only exports will not be reported as used.
+    /// However, the transitive dependencies of unused types will still be
+    /// reported as unused.
+    pub allow_unused_types: bool,
 
     /// Path to the root directory of the repository
     pub repo_root: String,
@@ -119,6 +128,7 @@ impl TryFrom<UnusedFinderJSONConfig> for UnusedFinderConfig {
         Ok(UnusedFinderConfig {
             // raw fields that are copied from the JSON config
             report_exported_symbols: value.report_exported_symbols,
+            allow_unused_types: value.allow_unused_types,
             root_paths: value.root_paths,
             repo_root: value.repo_root,
             // other fields that are processed before use

--- a/crates/unused_finder/src/graph.rs
+++ b/crates/unused_finder/src/graph.rs
@@ -22,6 +22,8 @@ bitflags::bitflags! {
         /// True if this file or symbol was used recursively by an
         /// ignored symbol or file.
         const FROM_IGNORED = 0x04;
+        // True if this symbol is a type-only symbol
+        const TYPE_ONLY = 0x08;
     }
 }
 
@@ -34,6 +36,9 @@ impl Display for UsedTag {
         if self.contains(Self::FROM_IGNORED) {
             tags.push("ignored");
         };
+        if self.contains(Self::TYPE_ONLY) {
+            tags.push("type-only");
+        }
         write!(f, "{}", tags.join("+"))
     }
 }

--- a/crates/unused_finder/src/graph.rs
+++ b/crates/unused_finder/src/graph.rs
@@ -1,5 +1,9 @@
 use core::{fmt, option::Option::None};
-use std::{collections::HashSet, fmt::Display, path::PathBuf};
+use std::{
+    collections::HashSet,
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use ahashmap::{AHashMap, AHashSet};
 use anyhow::Result;
@@ -149,6 +153,18 @@ impl Graph {
         Graph { path_to_id, files }
     }
 
+    pub fn mark_symbol(&mut self, path: &Path, symbol: &ExportedSymbol, tag: UsedTag) {
+        let file_id = match self.path_to_id.get(path) {
+            Some(id) => *id,
+            None => {
+                return;
+            }
+        };
+
+        let file = &mut self.files[file_id];
+        file.tag_symbol(symbol, tag);
+    }
+
     pub fn traverse_bfs(
         &mut self,
         logger: impl Logger,
@@ -255,10 +271,21 @@ impl Graph {
                 // TODO: become more granular here for re-exported symbols
                 let outgoing_edges = file
                     .import_export_info
-                    .iter_imported_symbols()
-                    .filter_map(|(path, symbol)| {
+                    .iter_imported_symbols_meta()
+                    .filter_map(|(path, symbol, meta)| {
+                        // don't traverse type-only re-exports of symbols when marking items.
+                        //
+                        // This is so that we don't mark a symbol as used if it is only used as a type.
+                        // TODO: should this be a TraversalMode that the graph is parameterized on? e.g.
+                        // track USED_ENTRY and USED_ENTRY_AS_TYPE as separate tags?
+                        if let Some(meta) = meta {
+                            if meta.is_type_only {
+                                return None;
+                            }
+                        }
+
                         let edge = match self.path_to_id.get(path) {
-                            Some(id) => Edge::new(*id, symbol),
+                            Some(id) => Edge::new(*id, symbol.clone()),
                             None => {
                                 return None;
                             }

--- a/crates/unused_finder/src/parse/data.rs
+++ b/crates/unused_finder/src/parse/data.rs
@@ -17,6 +17,15 @@ pub enum ExportedSymbol {
     ExecutionOnly, // in case of `import './foo';` this executes code in file but imports nothing
 }
 
+impl From<&str> for ExportedSymbol {
+    fn from(s: &str) -> Self {
+        match s {
+            "default" => ExportedSymbol::Default,
+            _ => ExportedSymbol::Named(s.to_string()),
+        }
+    }
+}
+
 impl std::fmt::Display for ExportedSymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -47,6 +56,8 @@ impl From<&ModuleExportName> for ExportedSymbol {
 pub struct ExportedSymbolMetadata {
     pub span: Span,
     pub allow_unused: bool,
+    // if this symbol is a typeonly export / import
+    pub is_type_only: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -69,7 +80,7 @@ pub struct RawImportExportInfo {
     // import('./foo') generates ["./foo"]
     pub imported_paths: AHashSet<String>,
     // `export {default as foo, bar} from './foo'` generates { "./foo": ["default", "bar"] }
-    pub export_from_ids: AHashMap<String, AHashSet<ReExportedSymbol>>,
+    pub export_from_ids: AHashMap<String, AHashMap<ReExportedSymbol, ExportedSymbolMetadata>>,
     // `export default foo` and `export {foo}` generate `Default` and `Named("foo")` respectively
     pub exported_ids: AHashMap<ExportedSymbol, ExportedSymbolMetadata>,
     // `import './foo'`
@@ -87,7 +98,7 @@ pub struct ResolvedImportExportInfo {
     // import('./foo') generates ["./foo"]
     pub imported_paths: AHashSet<PathBuf>,
     // `export {default as foo, bar} from './foo'` generates { "./foo": ["default", "bar"] }
-    pub export_from_symbols: AHashMap<PathBuf, AHashSet<ReExportedSymbol>>,
+    pub export_from_symbols: AHashMap<PathBuf, AHashMap<ReExportedSymbol, ExportedSymbolMetadata>>,
     // `export default foo` and `export {foo}` generate `Default` and `Named("foo")` respectively
     pub exported_ids: AHashMap<ExportedSymbol, ExportedSymbolMetadata>,
     // `import './foo'`
@@ -102,7 +113,7 @@ impl ResolvedImportExportInfo {
     /// Returns an iterator over all the imports originating from this file.
     pub fn iter_exported_symbols(&self) -> impl Iterator<Item = (Option<&Path>, &ExportedSymbol)> {
         let export_from_symbols = self.export_from_symbols.iter().flat_map(|(path, symbols)| {
-            symbols.iter().map(|symbol| {
+            symbols.iter().map(|(symbol, _meta)| {
                 (
                     Some(path.as_path()),
                     symbol.renamed_to.as_ref().unwrap_or(&symbol.imported),
@@ -135,7 +146,7 @@ impl ResolvedImportExportInfo {
         let re_exports = self.export_from_symbols.iter().flat_map(|(path, symbols)| {
             symbols
                 .iter()
-                .map(move |symbol| (path, symbol.imported.clone()))
+                .map(move |(symbol, _meta)| (path, symbol.imported.clone()))
         });
 
         let executed_paths = self

--- a/crates/unused_finder/src/parse/exports_visitor.rs
+++ b/crates/unused_finder/src/parse/exports_visitor.rs
@@ -136,7 +136,6 @@ impl ExportsVisitor {
         span: Span,
     ) {
         specs.iter().for_each(|specifier| {
-            println!("specifier: {:?}", specifier);
             if let ExportSpecifier::Named(named) = specifier {
                 let is_type_only: bool = parent_is_type_only || named.is_type_only;
                 // Handles `export { foo as bar }`

--- a/crates/unused_finder/src/report.rs
+++ b/crates/unused_finder/src/report.rs
@@ -21,6 +21,7 @@ pub struct SymbolReport {
 pub enum UsedTagEnum {
     Entry,
     Ignored,
+    TypeOnly,
 }
 impl From<UsedTag> for Option<Vec<UsedTagEnum>> {
     fn from(flags: UsedTag) -> Self {
@@ -34,6 +35,9 @@ impl From<UsedTag> for Option<Vec<UsedTagEnum>> {
         }
         if flags.contains(UsedTag::FROM_IGNORED) {
             result.push(UsedTagEnum::Ignored);
+        }
+        if flags.contains(UsedTag::TYPE_ONLY) {
+            result.push(UsedTagEnum::TypeOnly);
         }
 
         Some(result)

--- a/crates/unused_finder/src/report.rs
+++ b/crates/unused_finder/src/report.rs
@@ -148,6 +148,7 @@ impl From<&UnusedFinderResult> for UnusedFinderReport {
                             if symbol_bitflags.contains(UsedTag::FROM_ENTRY)
                                 || symbol_bitflags.contains(UsedTag::FROM_TEST)
                                 || symbol_bitflags.contains(UsedTag::FROM_IGNORED)
+                                || symbol_bitflags.contains(UsedTag::TYPE_ONLY)
                             {
                                 // don't return used symbols
                                 return None;

--- a/crates/unused_finder_napi/src/lib.rs
+++ b/crates/unused_finder_napi/src/lib.rs
@@ -38,6 +38,8 @@ pub struct UnusedFinderJSONConfig {
     /// If true, individual exported symbols are also tracked
     #[serde(default)]
     pub report_exported_symbols: bool,
+    #[serde(default)]
+    pub allow_unused_types: bool,
     /// List of packages that should be considered "entry" packages
     /// All transitive imports from the exposed exports of these packages
     /// will be considered used
@@ -57,6 +59,7 @@ impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
             skip: val.skip,
             report_exported_symbols: val.report_exported_symbols,
             entry_packages: val.entry_packages,
+            allow_unused_types: val.allow_unused_types,
         }
     }
 }
@@ -68,6 +71,8 @@ pub enum UsedTagEnum {
     Entry,
     #[serde(rename = "ignored")]
     Ignored,
+    #[serde(rename = "type-only")]
+    TypeOnly,
 }
 
 impl From<unused_finder::UsedTagEnum> for UsedTagEnum {
@@ -75,6 +80,7 @@ impl From<unused_finder::UsedTagEnum> for UsedTagEnum {
         match val {
             unused_finder::UsedTagEnum::Entry => UsedTagEnum::Entry,
             unused_finder::UsedTagEnum::Ignored => UsedTagEnum::Ignored,
+            unused_finder::UsedTagEnum::TypeOnly => UsedTagEnum::TypeOnly,
         }
     }
 }


### PR DESCRIPTION
## Motivations

Many of the unused symbols being reported by unused finder are type declarations used by exported symbols that don't themselves have additional bundle weight implications.

This change is intended to allow these situations without having to support intra-file reference tracking.

## Approach

The approach taken was to attach additional metadata to each declared export, as well as each declared re-export from another file, saying if the symbol is a type-only export.

This is later-on used to mark all type-only entrypoints in the graph with a new tag, which is used to filter them out of the report.

## Notes
As part of this change, I also refactored the export tracking so that type-only re-exports would not be followed during edge traversals. This is because type-only re-exports do not have an associated bundle weight.

I plan on revisiting this in a follow-up change, where the "entrypoints" traversal is split up into multiple separate traversals: one that follows type-only edges, and one that does not.

The "allow_unused_types" flag would add all exports to the entrypoints. This would allow us to determine when a concrete value is only ever used as a type value.