### PR TITLE
Run `npm pkg fix` in repo root

### DIFF
--- a/change/@good-fences-api-6c696660-0b84-426a-b838-398dda540094.json
+++ b/change/@good-fences-api-6c696660-0b84-426a-b838-398dda540094.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "run npm pkg fix",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Adjective-Object/good-fences-rs-core"
+    "url": "git+https://github.com/Adjective-Object/good-fences-rs-core.git"
   },
   "bin": {
-    "good-fences": "./good-fences.js",
-    "unused": "./unused.js"
+    "good-fences": "good-fences.js",
+    "unused": "unused.js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,8 +42,8 @@ __metadata:
     beachball: "npm:^2.36.0"
     commander: "npm:^9.4.1"
   bin:
-    good-fences: ./good-fences.js
-    unused: ./unused.js
+    good-fences: good-fences.js
+    unused: unused.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I ran `npm pkg fix` in repo root and committed the results

See this error log:
https://github.com/Adjective-Object/good-fences-rs-core/actions/runs/11672948170/job/32507548250#step:13:345

npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish Removed invalid "scripts"
