### PR TITLE
unittest.yml: remove redundant repo clone in health checks

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,9 +24,6 @@ jobs:
         run: yarn install
       - name: Check changefile
         run: yarn check-changefile
-      - uses: actions/checkout@v4
-        with:
-          components: clippy
       - uses: giraffate/clippy-action@v1
         with:
           reporter: 'github-pr-review'

--- a/change/@good-fences-api-5a2b5160-385b-486d-aac9-b8b3a519a284.json
+++ b/change/@good-fences-api-5a2b5160-385b-486d-aac9-b8b3a519a284.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "unittest.yml: remove redundant repo clone in health checks",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Removes the redundant repo clone in the repo health checks jon