### PR TITLE
Support for test-file exclusions

### DIFF
--- a/change/@good-fences-api-67c8e574-b15f-4542-a781-4b625f530df0.json
+++ b/change/@good-fences-api-67c8e574-b15f-4542-a781-4b625f530df0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for usage from test files",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/unused_finder/src/cfg/package_match_rules.rs
+++ b/crates/unused_finder/src/cfg/package_match_rules.rs
@@ -44,6 +44,12 @@ impl PackageMatchRules {
     }
 }
 
+impl PackageMatchRules {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
 impl<T: AsRef<str> + ToString> TryFrom<Vec<T>> for PackageMatchRules {
     type Error = ConfigError;
     fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {

--- a/crates/unused_finder_napi/src/lib.rs
+++ b/crates/unused_finder_napi/src/lib.rs
@@ -49,6 +49,13 @@ pub struct UnusedFinderJSONConfig {
     /// 2. If the item contains any of "~)('!*", it is treated as a name-glob, and evaluated as a glob against the names of packages.
     /// 3. Otherwise, the item is treated as the name of an individual package, and matched literally.
     pub entry_packages: Vec<String>,
+    /// List of globs that will be matched against files in the repository
+    ///
+    /// Matches are made against the relative file paths from the repo root.
+    /// A matching file will be tagged as a "test" file, and will be excluded
+    /// from the list of unused files
+    #[serde(default)]
+    pub test_file_patterns: Vec<String>,
 }
 
 impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
@@ -60,6 +67,7 @@ impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
             report_exported_symbols: val.report_exported_symbols,
             entry_packages: val.entry_packages,
             allow_unused_types: val.allow_unused_types,
+            test_file_patterns: val.test_file_patterns,
         }
     }
 }


### PR DESCRIPTION
Exclude test files with the new `testFilePatterns` config option.

Files matching these globs will be treated as used and tagged as test files, as well as the transitive imports of files matching these globs.