### PR TITLE
Return 'extra file tags' in report info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_print"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f215f9b7224f49fb73256115331f677d868b34d18b65dbe4db392e6021eea90"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2669,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "const_format",
+ "debug_print",
  "glob",
  "ignore",
  "import_resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
 dependencies = [
  "heck 0.4.1",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -2657,6 +2666,7 @@ dependencies = [
  "glob",
  "ignore",
  "import_resolver",
+ "itertools 0.13.0",
  "js_err",
  "packagejson",
  "packagejson_exports",

--- a/change/@good-fences-api-aa31c04e-9fa3-4be0-b954-b56665c76c6d.json
+++ b/change/@good-fences-api-aa31c04e-9fa3-4be0-b954-b56665c76c6d.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "unused_finder: track test files, return tagged symbols",
+  "comment": "unused_finder: return tagged symbols",
   "packageName": "@good-fences/api",
   "email": "mhuan13@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@good-fences-api-aa31c04e-9fa3-4be0-b954-b56665c76c6d.json
+++ b/change/@good-fences-api-aa31c04e-9fa3-4be0-b954-b56665c76c6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "unused_finder: track test files, return tagged symbols",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/unused_finder/Cargo.toml
+++ b/crates/unused_finder/Cargo.toml
@@ -36,6 +36,7 @@ bitflags = "2.6.0"
 ignore = "0.4.23"
 abspath = { version = "0.2.0", path = "../abspath" }
 itertools = "0.13.0"
+debug_print = "1.0.0"
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/crates/unused_finder/Cargo.toml
+++ b/crates/unused_finder/Cargo.toml
@@ -35,6 +35,7 @@ ahashmap = { path = "../ahashmap" }
 bitflags = "2.6.0"
 ignore = "0.4.23"
 abspath = { version = "0.2.0", path = "../abspath" }
+itertools = "0.13.0"
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/crates/unused_finder/src/cfg/mod.rs
+++ b/crates/unused_finder/src/cfg/mod.rs
@@ -103,31 +103,13 @@ pub struct UnusedFinderJSONConfig {
     /// 3. Otherwise, the item is treated as the name of an individual package, and matched
     ///    literally.
     pub entry_packages: Vec<String>,
-    /// List of globs that will be matched against files in the repository
-,
-    ///
-,
-    /// Matches are made against the relative file paths from the repo root.
-,
-    /// A matching file will be tagged as a "test" file, and will be excluded
-,
-    /// from the list of unused files
-,
-    #[serde(default)],
-    pub test_file_patterns: Vec<String>,
     /// List of glob patterns to mark as "tests".
-,
     /// These files will be marked as used, and all of their transitive
-,
     /// dependencies will also be marked as used
-,
     ///
-,
     /// glob patterns are matched against the relative file path from the
-,
     /// root of the repository
-,
-    #[serde(default)],
+    #[serde(default)]
     pub test_files: Vec<String>,
 }
 
@@ -155,16 +137,13 @@ pub struct UnusedFinderConfig {
     /// Matches are made against the relative file paths from the repo root.
     /// A matching file will be tagged as a "test" file, and will be excluded
     /// from the list of unused files
-    pub test_file_patterns: Vec<glob::Pattern>,
+    pub test_files: Vec<glob::Pattern>,
 
     /// Globs of individual files & directories to skip during the file walk.
     ///
     /// Some internal directories are always skipped.
     /// See [crate::walk::DEFAULT_SKIPPED_DIRS] for more details.
     pub skip: Vec<String>,
-
-    /// List of glob patterns of test files
-    pub test_files: Vec<glob::Pattern>,
 }
 
 impl TryFrom<UnusedFinderJSONConfig> for UnusedFinderConfig {
@@ -189,16 +168,8 @@ impl TryFrom<UnusedFinderJSONConfig> for UnusedFinderConfig {
             repo_root: value.repo_root,
             // other fields that are processed before use
             entry_packages: value.entry_packages.try_into()?,
-            test_file_patterns: value
-                .test_file_patterns
-                .iter()
-                .map(|p| glob::Pattern::new(p))
-                .collect::<Result<_, _>>()
-                .map_err(|e| {
-                    ConfigError::InvalidGlobPatterns(ErrList(vec![PatErr(0, GlobInterp::Path, e)]))
-                })?,
-            skip: value.skip,
             test_files: test_globs,
+            skip: value.skip,
         })
     }
 }

--- a/crates/unused_finder/src/graph.rs
+++ b/crates/unused_finder/src/graph.rs
@@ -1,9 +1,20 @@
+<<<<<<< HEAD
 use core::{fmt, option::Option::None};
 use std::{
     collections::HashSet,
     fmt::Display,
     path::{Path, PathBuf},
 };
+||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
+use core::{fmt, option::Option::None};
+use std::{collections::HashSet, fmt::Display, path::PathBuf};
+=======
+use core::option::Option::None;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+>>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 
 use ahashmap::{AHashMap, AHashSet};
 use anyhow::Result;
@@ -31,6 +42,7 @@ bitflags::bitflags! {
     }
 }
 
+<<<<<<< HEAD
 impl Display for UsedTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut tags = Vec::new();
@@ -47,6 +59,22 @@ impl Display for UsedTag {
     }
 }
 
+||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
+impl Display for UsedTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut tags = Vec::new();
+        if self.contains(Self::FROM_ENTRY) {
+            tags.push("entry");
+        };
+        if self.contains(Self::FROM_IGNORED) {
+            tags.push("ignored");
+        };
+        write!(f, "{}", tags.join("+"))
+    }
+}
+
+=======
+>>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 // graph node used to represent a file during the "used file" walk
 #[derive(Debug, Clone, Default)]
 pub struct GraphFile {
@@ -168,13 +196,13 @@ impl Graph {
     pub fn traverse_bfs(
         &mut self,
         logger: impl Logger,
-        initial_frontier_files: Vec<PathBuf>,
-        initial_frontier_symbols: Vec<(PathBuf, Vec<ExportedSymbol>)>,
+        initial_frontier_files: Vec<&Path>,
+        initial_frontier_symbols: Vec<(&Path, Vec<ExportedSymbol>)>,
         tag: UsedTag,
     ) -> Result<()> {
         let initial_file_edges = initial_frontier_files
             .into_iter()
-            .filter_map(|path| match self.path_to_id.get(&path) {
+            .filter_map(|path| match self.path_to_id.get(path) {
                 Some(file_id) => Some(*file_id),
                 None => {
                     logger.log(format!(
@@ -189,8 +217,8 @@ impl Graph {
         let initial_symbol_edges = initial_frontier_symbols
             .into_iter()
             .filter_map(
-                |(path, symbols): (PathBuf, Vec<ExportedSymbol>)| -> Option<Vec<Edge>> {
-                    match self.path_to_id.get(&path).cloned() {
+                |(path, symbols): (&Path, Vec<ExportedSymbol>)| -> Option<Vec<Edge>> {
+                    match self.path_to_id.get(path).cloned() {
                         Some(file_id) => Some(
                             symbols
                                 .into_iter()

--- a/crates/unused_finder/src/graph.rs
+++ b/crates/unused_finder/src/graph.rs
@@ -1,20 +1,5 @@
-<<<<<<< HEAD
-use core::{fmt, option::Option::None};
-use std::{
-    collections::HashSet,
-    fmt::Display,
-    path::{Path, PathBuf},
-};
-||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
-use core::{fmt, option::Option::None};
-use std::{collections::HashSet, fmt::Display, path::PathBuf};
-=======
 use core::option::Option::None;
-use std::{
-    collections::HashSet,
-    path::{Path, PathBuf},
-};
->>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
+use std::{collections::HashSet, path::Path, path::PathBuf};
 
 use ahashmap::{AHashMap, AHashSet};
 use anyhow::Result;
@@ -23,58 +8,10 @@ use rayon::prelude::*;
 use crate::{
     logger::Logger,
     parse::{ExportedSymbol, ResolvedImportExportInfo},
+    tag::UsedTag,
     walked_file::ResolvedSourceFile,
 };
 
-bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
-    pub struct UsedTag: u8 {
-        /// True if this file or symbol was used recursively by an
-        /// "entry package" (a package that was passed as an entry point).
-        const FROM_ENTRY = 0x01;
-        /// True if this file or symbol was used recursively by a test file.
-        const FROM_TEST = 0x02;
-        /// True if this file or symbol was used recursively by an
-        /// ignored symbol or file.
-        const FROM_IGNORED = 0x04;
-        // True if this symbol is a type-only symbol
-        const TYPE_ONLY = 0x08;
-    }
-}
-
-<<<<<<< HEAD
-impl Display for UsedTag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut tags = Vec::new();
-        if self.contains(Self::FROM_ENTRY) {
-            tags.push("entry");
-        };
-        if self.contains(Self::FROM_IGNORED) {
-            tags.push("ignored");
-        };
-        if self.contains(Self::TYPE_ONLY) {
-            tags.push("type-only");
-        }
-        write!(f, "{}", tags.join("+"))
-    }
-}
-
-||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
-impl Display for UsedTag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut tags = Vec::new();
-        if self.contains(Self::FROM_ENTRY) {
-            tags.push("entry");
-        };
-        if self.contains(Self::FROM_IGNORED) {
-            tags.push("ignored");
-        };
-        write!(f, "{}", tags.join("+"))
-    }
-}
-
-=======
->>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 // graph node used to represent a file during the "used file" walk
 #[derive(Debug, Clone, Default)]
 pub struct GraphFile {

--- a/crates/unused_finder/src/lib.rs
+++ b/crates/unused_finder/src/lib.rs
@@ -18,6 +18,7 @@ mod ignore_file;
 pub mod logger;
 mod parse;
 mod report;
+mod tag;
 #[cfg(test)]
 mod test;
 mod unused_finder;
@@ -26,7 +27,8 @@ mod walked_file;
 
 pub use cfg::{UnusedFinderConfig, UnusedFinderJSONConfig};
 pub use parse::data::ResolvedImportExportInfo;
-pub use report::{SymbolReport, UnusedFinderReport, UsedTagEnum};
+pub use report::{SymbolReport, SymbolReportWithTags, UnusedFinderReport};
+pub use tag::UsedTagEnum;
 pub use unused_finder::{UnusedFinder, UnusedFinderResult};
 
 pub fn find_unused_items(

--- a/crates/unused_finder/src/report.rs
+++ b/crates/unused_finder/src/report.rs
@@ -1,11 +1,21 @@
-use core::option::Option::None;
-use std::{collections::BTreeMap, fmt::Display};
+use core::{
+    convert::Into,
+    option::Option::{None, Some},
+};
+use std::fmt::Display;
 
+use ahashmap::AHashMap;
+use itertools::Either;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use swc_common::source_map::SmallPos;
 
-use crate::{graph::UsedTag, parse::ExportedSymbol, UnusedFinderResult};
+use crate::{
+    graph::{Graph, GraphFile, UsedTag},
+    parse::ExportedSymbol,
+    tag::UsedTagEnum,
+    UnusedFinderResult,
+};
 
 // Report of a single exported item in a file
 #[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize)]
@@ -13,22 +23,30 @@ pub struct SymbolReport {
     pub id: String,
     pub start: u32,
     pub end: u32,
-    pub tags: Option<Vec<UsedTagEnum>>,
 }
 
+<<<<<<< HEAD
 #[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum UsedTagEnum {
     Entry,
     Ignored,
     TypeOnly,
+||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
+#[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UsedTagEnum {
+    Entry,
+    Ignored,
+=======
+#[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize)]
+pub struct SymbolReportWithTags {
+    pub symbol: SymbolReport,
+    pub tags: Vec<UsedTagEnum>,
+>>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 }
-impl From<UsedTag> for Option<Vec<UsedTagEnum>> {
-    fn from(flags: UsedTag) -> Self {
-        if flags.is_empty() {
-            return None;
-        }
 
+<<<<<<< HEAD
         let mut result = Vec::new();
         if flags.contains(UsedTag::FROM_ENTRY) {
             result.push(UsedTagEnum::Entry);
@@ -42,17 +60,38 @@ impl From<UsedTag> for Option<Vec<UsedTagEnum>> {
 
         Some(result)
     }
+||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
+        let mut result = Vec::new();
+        if flags.contains(UsedTag::FROM_ENTRY) {
+            result.push(UsedTagEnum::Entry);
+        }
+        if flags.contains(UsedTag::FROM_IGNORED) {
+            result.push(UsedTagEnum::Ignored);
+        }
+
+        Some(result)
+    }
+=======
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FileInfo {
+    tags: Vec<UsedTagEnum>,
+    symbols: AHashMap<String, Vec<SymbolReport>>,
+>>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 }
 
 // Report of unused symbols within a project
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct UnusedFinderReport {
-    // files that are completely unused
+    /// Files that are completely unused
     pub unused_files: Vec<String>,
-    // items that are unused within files
-    // note that this intentionally uses a std HashMap type to guarantee napi
-    // compatibility
-    pub unused_symbols: BTreeMap<String, Vec<SymbolReport>>,
+    /// Exported symbols that are unused within files
+    /// note that this intentionally uses a std HashMap type to guarantee napi
+    /// compatibility
+    pub unused_symbols: AHashMap<String, Vec<SymbolReport>>,
+
+    /// File tag information for files that are used.
+    pub extra_file_tags: AHashMap<String, Vec<UsedTagEnum>>,
+    pub extra_symbol_tags: AHashMap<String, Vec<SymbolReportWithTags>>,
 }
 
 impl Display for UnusedFinderReport {
@@ -102,49 +141,82 @@ impl Display for UnusedFinderReport {
     }
 }
 
+fn extract_symbols<T: Send + Sync>(
+    graph: &Graph,
+    include_symbol: impl Fn(&GraphFile, &ExportedSymbol) -> Option<T> + Sync,
+) -> AHashMap<String, Vec<T>> {
+    graph
+        .files
+        .par_iter()
+        .filter_map(|graph_file| -> Option<(String, Vec<T>)> {
+            // Find all used symbols in the file
+            let unused_symbols = graph_file
+                .import_export_info
+                .iter_exported_symbols()
+                .filter_map(|(_, symbol): (_, &ExportedSymbol)| -> Option<T> {
+                    include_symbol(graph_file, symbol)
+                })
+                .collect::<Vec<_>>();
+
+            if unused_symbols.is_empty() {
+                return None;
+            }
+
+            Some((
+                graph_file.file_path.to_string_lossy().to_string(),
+                unused_symbols,
+            ))
+        })
+        .collect::<AHashMap<String, Vec<T>>>()
+}
+
 impl From<&UnusedFinderResult> for UnusedFinderReport {
     fn from(value: &UnusedFinderResult) -> Self {
-        let mut unused_files: Vec<String> = value
-            .graph
-            .files
-            .par_iter()
-            .filter_map(|file| {
-                if file.file_tags.contains(UsedTag::FROM_ENTRY)
-                    || file.file_tags.contains(UsedTag::FROM_TEST)
-                    || file.file_tags.contains(UsedTag::FROM_IGNORED)
-                {
-                    None
-                } else {
-                    Some(file.file_path.to_string_lossy().to_string())
-                }
-            })
-            .collect();
+        let (mut unused_files, extra_file_tags): (Vec<String>, AHashMap<String, Vec<UsedTagEnum>>) =
+            value
+                .graph
+                .files
+                .par_iter()
+                .filter(|file| {
+                    !file.file_tags.contains(UsedTag::FROM_ENTRY)
+                        && !file.file_tags.contains(UsedTag::FROM_TEST)
+                        && !file.file_tags.contains(UsedTag::FROM_IGNORED)
+                })
+                .partition_map(|file| {
+                    if !file.file_tags.contains(UsedTag::FROM_ENTRY) {
+                        Either::Left(file.file_path.to_string_lossy().to_string())
+                    } else {
+                        Either::Right((
+                            file.file_path.to_string_lossy().to_string(),
+                            file.file_tags.into(),
+                        ))
+                    }
+                });
         unused_files.sort();
 
-        let unused_symbols: BTreeMap<String, Vec<SymbolReport>> = value
-            .graph
-            .files
-            .par_iter()
-            .filter_map(|graph_file| -> Option<(String, Vec<SymbolReport>)> {
-                // Find all used symbols in the file
-                let unused_symbols = graph_file
-                    .import_export_info
-                    .iter_exported_symbols()
-                    .filter_map(
-                        |(_, symbol): (_, &ExportedSymbol)| -> Option<SymbolReport> {
-                            let symbol_bitflags: UsedTag = graph_file
-                                .symbol_tags
-                                .get(symbol)
-                                .copied()
-                                .unwrap_or_default();
-                            let ast_symbol =
-                                match graph_file.import_export_info.exported_ids.get(symbol) {
-                                    Some(ast_symbol) => ast_symbol,
-                                    None => {
-                                        return None;
-                                    }
-                                };
+        let unused_symbols =
+            extract_symbols(&value.graph, |file, symbol_name| -> Option<SymbolReport> {
+                let default: UsedTag = Default::default();
+                let symbol_bitflags: &UsedTag =
+                    file.symbol_tags.get(symbol_name).unwrap_or(&default);
+                println!(
+                    "visit symbol {}:{}  ({})",
+                    file.file_path.display(),
+                    symbol_name,
+                    symbol_bitflags
+                );
 
+                if symbol_bitflags.contains(UsedTag::FROM_ENTRY)
+                    || symbol_bitflags.contains(UsedTag::FROM_TEST)
+                    || symbol_bitflags.contains(UsedTag::FROM_IGNORED)
+                {
+                    // don't return used symbols
+                    return None;
+                }
+
+                let ast_symbol = file.import_export_info.exported_ids.get(symbol_name)?;
+
+<<<<<<< HEAD
                             if symbol_bitflags.contains(UsedTag::FROM_ENTRY)
                                 || symbol_bitflags.contains(UsedTag::FROM_TEST)
                                 || symbol_bitflags.contains(UsedTag::FROM_IGNORED)
@@ -153,32 +225,64 @@ impl From<&UnusedFinderResult> for UnusedFinderReport {
                                 // don't return used symbols
                                 return None;
                             }
+||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
+                            if symbol_bitflags.contains(UsedTag::FROM_ENTRY)
+                                || symbol_bitflags.contains(UsedTag::FROM_TEST)
+                                || symbol_bitflags.contains(UsedTag::FROM_IGNORED)
+                            {
+                                // don't return used symbols
+                                return None;
+                            }
+=======
+                Some(SymbolReport {
+                    id: symbol_name.to_string(),
+                    start: ast_symbol.span.lo().to_u32(),
+                    end: ast_symbol.span.hi().to_u32(),
+                })
+            });
+>>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
 
-                            Some(SymbolReport {
-                                id: symbol.to_string(),
-                                start: ast_symbol.span.lo().to_u32(),
-                                end: ast_symbol.span.hi().to_u32(),
-                                // for symbols that are not used by entrypoints, return the bitflags where they _are_ used
-                                tags: symbol_bitflags.into(),
-                            })
-                        },
-                    )
-                    .collect::<Vec<_>>();
+        let extra_symbol_tags = extract_symbols(
+            &value.graph,
+            |file, symbol_name| -> Option<SymbolReportWithTags> {
+                let default: UsedTag = Default::default();
+                let symbol_bitflags: &UsedTag =
+                    file.symbol_tags.get(symbol_name).unwrap_or(&default);
+                println!(
+                    "visit symbol {}:{}  ({})",
+                    file.file_path.display(),
+                    symbol_name,
+                    symbol_bitflags
+                );
 
-                if unused_symbols.is_empty() {
+                if symbol_bitflags.contains(UsedTag::FROM_ENTRY)
+                    || !symbol_bitflags.contains(UsedTag::FROM_TEST)
+                        && !symbol_bitflags.contains(UsedTag::FROM_IGNORED)
+                {
+                    // don't return symbols that are used or symbols that are truly unused
                     return None;
                 }
 
-                Some((
-                    graph_file.file_path.to_string_lossy().to_string(),
-                    unused_symbols,
-                ))
-            })
-            .collect::<BTreeMap<String, Vec<SymbolReport>>>();
+                let ast_symbol = file.import_export_info.exported_ids.get(symbol_name)?;
+
+                Some(SymbolReportWithTags {
+                    symbol: SymbolReport {
+                        id: symbol_name.to_string(),
+                        start: ast_symbol.span.lo().to_u32(),
+                        end: ast_symbol.span.hi().to_u32(),
+                    },
+                    tags: (*symbol_bitflags).into(),
+                })
+            },
+        );
 
         UnusedFinderReport {
             unused_files,
             unused_symbols,
+            // TODO collect tags from symbols are "used", but not
+            // entrypoints into the project
+            extra_file_tags,
+            extra_symbol_tags,
         }
     }
 }

--- a/crates/unused_finder/src/tag.rs
+++ b/crates/unused_finder/src/tag.rs
@@ -1,0 +1,58 @@
+use core::fmt::{self, Display};
+use serde::{Deserialize, Serialize};
+
+use crate::graph::UsedTag;
+
+/// Bitflag used internally to represent the tags on a file or symbol
+impl Display for UsedTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut tags = Vec::new();
+        if self.contains(Self::FROM_ENTRY) {
+            tags.push("entry");
+        };
+        if self.contains(Self::FROM_IGNORED) {
+            tags.push("ignored");
+        };
+        if self.contains(Self::FROM_TEST) {
+            tags.push("test");
+        };
+        write!(f, "{}", tags.join("+"))
+    }
+}
+
+/// External-facing enum type used to represent the tags on a file or symbol
+#[derive(Debug, PartialEq, Ord, PartialOrd, Eq, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UsedTagEnum {
+    Entry,
+    Ignored,
+    Test,
+}
+
+impl From<UsedTag> for Option<Vec<UsedTagEnum>> {
+    fn from(flags: UsedTag) -> Self {
+        if flags.is_empty() {
+            return None;
+        }
+
+        let result: Vec<UsedTagEnum> = flags.into();
+        Some(result)
+    }
+}
+
+impl From<UsedTag> for Vec<UsedTagEnum> {
+    fn from(flags: UsedTag) -> Self {
+        let mut result = Vec::new();
+        if flags.contains(UsedTag::FROM_ENTRY) {
+            result.push(UsedTagEnum::Entry);
+        }
+        if flags.contains(UsedTag::FROM_IGNORED) {
+            result.push(UsedTagEnum::Ignored);
+        }
+        if flags.contains(UsedTag::FROM_TEST) {
+            result.push(UsedTagEnum::Test);
+        }
+
+        result
+    }
+}

--- a/crates/unused_finder/src/test.rs
+++ b/crates/unused_finder/src/test.rs
@@ -5,9 +5,8 @@ use path_slash::PathBufExt;
 use test_tmpdir::{amap, test_tmpdir};
 
 use crate::{
-    cfg::package_match_rules::PackageMatchRules, graph::UsedTag, logger, report::SymbolReport, SymbolReportWithTags,
-    UnusedFinder,
-    UnusedFinderConfig, UnusedFinderReport,
+    cfg::package_match_rules::PackageMatchRules, logger, report::SymbolReport, tag::UsedTag,
+    SymbolReportWithTags, UnusedFinder, UnusedFinderConfig, UnusedFinderReport,
 };
 
 fn symbol(id: &str) -> SymbolReport {
@@ -354,13 +353,15 @@ ignored-*.js
                     symbol("exception"),
                 ]
             ),
+            extra_file_tags: amap!(
+                "<root>/packages/root/ignored-unused.js" => UsedTag::FROM_IGNORED.into()
+            ),
             extra_symbol_tags: amap!(
                 "<root>/packages/root/ignored-unused.js" => vec![
                     tagged_symbol("a", UsedTag::FROM_IGNORED),
                     tagged_symbol("b", UsedTag::FROM_IGNORED),
                 ]
             ),
-            ..Default::default()
         },
     );
 }
@@ -396,7 +397,7 @@ fn test_non_root_root_path() {
 
 #[test]
 fn test_test_pattern() {
-    // Tests that the package traversal works when there is a non-root "root" path.
+    // Tests tagging "test" files
     let tmpdir = test_tmpdir!(
         "search_root/packages/utils/testUtils.js" => r#"
             export const testSymbol = "testSymbol";
@@ -419,6 +420,10 @@ fn test_test_pattern() {
             ..Default::default()
         },
         UnusedFinderReport {
+            extra_file_tags: amap!(
+                "<root>/search_root/packages/__tests__/myTest.js" => UsedTag::FROM_TEST.into(),
+                "<root>/search_root/packages/utils/testUtils.js" => UsedTag::FROM_TEST.into()
+            ),
             extra_symbol_tags: amap!(
                 "<root>/search_root/packages/utils/testUtils.js" => vec![
                     tagged_symbol("testSymbol", UsedTag::FROM_TEST),
@@ -431,7 +436,7 @@ fn test_test_pattern() {
 
 #[test]
 fn test_relative_test_pattern() {
-    // Tests that the package traversal works when there is a non-root "root" path.
+    // Tests tagging "test" files with relative patterns
     let tmpdir = test_tmpdir!(
         "search_root/packages/test-utils/testUtils.js" => r#"
             export const testSymbol = "testSymbol";
@@ -454,89 +459,16 @@ fn test_relative_test_pattern() {
             ..Default::default()
         },
         UnusedFinderReport {
+            extra_file_tags: amap!(
+                "<root>/search_root/tests/myTest.js" => UsedTag::FROM_TEST.into(),
+                "<root>/search_root/packages/test-utils/testUtils.js" => UsedTag::FROM_TEST.into()
+            ),
             extra_symbol_tags: amap!(
                 "<root>/search_root/packages/test-utils/testUtils.js" => vec![
                     tagged_symbol("testSymbol", UsedTag::FROM_TEST),
                 ]
             ),
             ..Default::default()
-        },
-    );
-}
-
-#[test]
-fn test_indirect_typeonly_export() {
-    // Tests that the package traversal works when there is a non-root "root" path.
-    let tmpdir = test_tmpdir!(
-        "search_root/packages/root/package.json" => r#"{
-            "name": "entrypoint",
-            "main": "./main.js",
-            "exports": {}
-        }"#,
-        "search_root/packages/root/main.js" => r#"
-            export type { ReExportedAsTypeOnly } from "./other";
-        "#,
-        "search_root/packages/root/other.js" => r#"
-            export class ReExportedAsTypeOnly {}
-            export class NotReExported {}
-        "#
-    );
-
-    run_unused_test(
-        &tmpdir,
-        UnusedFinderConfig {
-            repo_root: tmpdir.root().to_string_lossy().to_string(),
-            root_paths: vec!["search_root".to_string()],
-            entry_packages: vec!["entrypoint"].try_into().unwrap(),
-            allow_unused_types: true,
-            ..Default::default()
-        },
-        UnusedFinderReport {
-            unused_files: vec!["<root>/search_root/packages/root/other.js".to_string()],
-            unused_symbols: bmap![
-                "<root>/search_root/packages/root/other.js" => vec![
-                    symbol("NotReExported", UsedTag::default()),
-                    symbol("ReExportedAsTypeOnly", UsedTag::default()),
-                ]
-            ],
-        },
-    );
-}
-
-#[test]
-fn test_typeonly_interface_allowed() {
-    // Tests that the package traversal works when there is a non-root "root" path.
-    let tmpdir = test_tmpdir!(
-        "search_root/packages/root/package.json" => r#"{
-            "name": "entrypoint",
-            "main": "./main.js",
-            "exports": {}
-        }"#,
-        "search_root/packages/root/main.js" => r#"
-            export { ReExported } from "./other";
-        "#,
-        "search_root/packages/root/other.js" => r#"
-            // This should be allowed because it is a typeonly export
-            export interface MyInterface {
-                getFoo: () => string;
-            }
-
-            export class ReExported<T extends MyInterface> {}
-        "#
-    );
-
-    run_unused_test(
-        &tmpdir,
-        UnusedFinderConfig {
-            repo_root: tmpdir.root().to_string_lossy().to_string(),
-            root_paths: vec!["search_root".to_string()],
-            entry_packages: vec!["entrypoint"].try_into().unwrap(),
-            allow_unused_types: true,
-            ..Default::default()
-        },
-        UnusedFinderReport {
-            unused_files: vec![],
-            unused_symbols: bmap![],
         },
     );
 }
@@ -570,14 +502,101 @@ fn test_testfiles_ignored() {
             repo_root: tmpdir.root().to_string_lossy().to_string(),
             root_paths: vec!["search_root".to_string()],
             entry_packages: PackageMatchRules::empty(),
-            test_file_patterns: vec![glob::Pattern::from_str("**/__tests__/**").unwrap()],
+            test_files: vec![glob::Pattern::from_str("**/__tests__/**").unwrap()],
             ..Default::default()
         },
         UnusedFinderReport {
             unused_files: vec!["<root>/search_root/packages/test-helpers/unused-helpers.js".into()],
-            unused_symbols: bmap![
-                "<root>/search_root/packages/test-helpers/unused-helpers.js" => vec![symbol("myFunction", UsedTag::default())]
+            unused_symbols: amap![
+                "<root>/search_root/packages/test-helpers/unused-helpers.js" => vec![symbol("myFunction")]
             ],
+            extra_file_tags: amap![
+                "<root>/search_root/packages/test-helpers/test-helpers.js" => UsedTag::FROM_TEST.into(),
+                "<root>/search_root/packages/__tests__/myTests.test.js" => UsedTag::FROM_TEST.into()
+            ],
+            extra_symbol_tags: amap![
+                "<root>/search_root/packages/test-helpers/test-helpers.js" => vec![tagged_symbol("myFunction", UsedTag::FROM_TEST)]
+            ],
+        },
+    );
+}
+
+#[test]
+fn test_indirect_typeonly_export() {
+    // Tests typeonly exports do not propogate as "used"
+    let tmpdir = test_tmpdir!(
+        "search_root/packages/root/package.json" => r#"{
+            "name": "entrypoint",
+            "main": "./main.js",
+            "exports": {}
+        }"#,
+        "search_root/packages/root/main.js" => r#"
+            export type { ReExportedAsTypeOnly } from "./other";
+        "#,
+        "search_root/packages/root/other.js" => r#"
+            export class ReExportedAsTypeOnly {}
+            export class NotReExported {}
+        "#
+    );
+
+    run_unused_test(
+        &tmpdir,
+        UnusedFinderConfig {
+            repo_root: tmpdir.root().to_string_lossy().to_string(),
+            root_paths: vec!["search_root".to_string()],
+            entry_packages: vec!["entrypoint"].try_into().unwrap(),
+            allow_unused_types: true,
+            ..Default::default()
+        },
+        UnusedFinderReport {
+            unused_files: vec!["<root>/search_root/packages/root/other.js".to_string()],
+            unused_symbols: amap![
+                "<root>/search_root/packages/root/other.js" => vec![
+                    symbol("NotReExported"),
+                    symbol("ReExportedAsTypeOnly"),
+                ]
+            ],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_typeonly_interface_allowed() {
+    // Tests that interfaces are considered typeonly exports
+    let tmpdir = test_tmpdir!(
+        "search_root/packages/root/package.json" => r#"{
+            "name": "entrypoint",
+            "main": "./main.js",
+            "exports": {}
+        }"#,
+        "search_root/packages/root/main.js" => r#"
+            export { ReExported } from "./other";
+        "#,
+        "search_root/packages/root/other.js" => r#"
+            // This should be allowed because it is a typeonly export
+            export interface MyInterface {
+                getFoo: () => string;
+            }
+
+            export class ReExported<T extends MyInterface> {}
+        "#
+    );
+
+    run_unused_test(
+        &tmpdir,
+        UnusedFinderConfig {
+            repo_root: tmpdir.root().to_string_lossy().to_string(),
+            root_paths: vec!["search_root".to_string()],
+            entry_packages: vec!["entrypoint"].try_into().unwrap(),
+            allow_unused_types: true,
+            ..Default::default()
+        },
+        UnusedFinderReport {
+            extra_symbol_tags: amap![
+                "<root>/search_root/packages/root/other.js" => vec![tagged_symbol("MyInterface", UsedTag::TYPE_ONLY)]
+            ],
+            ..Default::default()
         },
     );
 }

--- a/crates/unused_finder/src/test.rs
+++ b/crates/unused_finder/src/test.rs
@@ -1,18 +1,26 @@
+use core::result::Result;
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use path_slash::PathBufExt;
-use test_tmpdir::{bmap, test_tmpdir};
+use test_tmpdir::{amap, test_tmpdir};
 
 use crate::{
-    cfg::package_match_rules::PackageMatchRules, graph::UsedTag, logger, report::SymbolReport,
-    UnusedFinder, UnusedFinderConfig, UnusedFinderReport,
+    cfg::package_match_rules::PackageMatchRules, graph::UsedTag, logger, report::SymbolReport, SymbolReportWithTags,
+    UnusedFinder,
+    UnusedFinderConfig, UnusedFinderReport,
 };
 
-fn symbol(id: &str, tags: UsedTag) -> SymbolReport {
+fn symbol(id: &str) -> SymbolReport {
     SymbolReport {
         id: id.to_string(),
         start: 0,
         end: 0,
+    }
+}
+
+fn tagged_symbol(id: &str, tags: UsedTag) -> SymbolReportWithTags {
+    SymbolReportWithTags {
+        symbol: symbol(id),
         tags: tags.into(),
     }
 }
@@ -35,6 +43,20 @@ fn normalize_test_report(
             .collect(),
         unused_symbols: result
             .unused_symbols
+            .into_iter()
+            .map(|(k, v)| {
+                let mut s_v = v.clone();
+                s_v.sort();
+                (normalize_path(tmpdir, &k), s_v)
+            })
+            .collect(),
+        extra_file_tags: result
+            .extra_file_tags
+            .into_iter()
+            .map(|(k, v)| (normalize_path(tmpdir, &k), v))
+            .collect(),
+        extra_symbol_tags: result
+            .extra_symbol_tags
             .into_iter()
             .map(|(k, v)| {
                 let mut s_v = v.clone();
@@ -86,6 +108,27 @@ fn run_unused_test(
                 .insert(item.id.clone(), (item.start, item.end));
         }
     }
+    for (file_path, symbols) in report.extra_symbol_tags.iter() {
+        let content_bytes = std::fs::read(file_path).unwrap();
+        for tagged_symbol in symbols.iter() {
+            let symbol = &tagged_symbol.symbol;
+            // check that the bytes in the slice match the expected symbol
+            let symbol_bytes = &content_bytes[(symbol.start - 1) as usize..symbol.end as usize];
+            let symbol_str = String::from_utf8(symbol_bytes.to_vec()).unwrap();
+            if !symbol_str.contains(&symbol.id) {
+                panic!(
+                    "Symbol {} with range {}:{} has incorrect offsets. Actual range contents: {:?}",
+                    symbol.id, symbol.start, symbol.end, symbol_str
+                );
+            }
+
+            // store the location of the symbol
+            actual_symbol_ranges
+                .entry(normalize_path(tmpdir, file_path))
+                .or_default()
+                .insert(symbol.id.clone(), (symbol.start, symbol.end));
+        }
+    }
 
     // for each of the symbols in the expected map, if the offsets are zero,
     // replace them with the actual offsets from the actual map
@@ -100,6 +143,19 @@ fn run_unused_test(
                 {
                     item.start = *start;
                     item.end = *end;
+                }
+            }
+        }
+    }
+    for (file_path, items) in expected.extra_symbol_tags.iter_mut() {
+        for item in items.iter_mut() {
+            if item.symbol.start == 0 && item.symbol.end == 0 {
+                if let Some((start, end)) = actual_symbol_ranges
+                    .get(file_path)
+                    .and_then(|m| m.get(&item.symbol.id))
+                {
+                    item.symbol.start = *start;
+                    item.symbol.end = *end;
                 }
             }
         }
@@ -149,7 +205,7 @@ fn test_package_exports_walk_roots() {
             .iter()
             .map(|x| x.to_string())
             .collect(),
-            unused_symbols: bmap!(),
+            ..Default::default()
         },
     );
 }
@@ -175,8 +231,7 @@ fn test_root_export_symbols_used() {
             ..Default::default()
         },
         UnusedFinderReport {
-            unused_files: vec![],
-            unused_symbols: bmap!(),
+            ..Default::default()
         },
     );
 }
@@ -208,8 +263,7 @@ fn test_transitive_re_export() {
             ..Default::default()
         },
         UnusedFinderReport {
-            unused_files: vec![],
-            unused_symbols: bmap!(),
+            ..Default::default()
         },
     );
 }
@@ -240,11 +294,12 @@ fn test_partially_unused_file() {
         },
         UnusedFinderReport {
             unused_files: vec![],
-            unused_symbols: bmap!(
+            unused_symbols: amap!(
                 "<root>/packages/root/imported-1.js" => vec![
-                    symbol("b", UsedTag::default()),
+                    symbol("b"),
                 ]
             ),
+            ..Default::default()
         },
     );
 }
@@ -290,15 +345,22 @@ ignored-*.js
             .iter()
             .map(|x| x.to_string())
             .collect(),
-            unused_symbols: bmap!(
+            unused_symbols: amap!(
                 "<root>/packages/root/unused.js" => vec![
-                    symbol("a", UsedTag::default()),
-                    symbol("b", UsedTag::default()),
+                    symbol("a"),
+                    symbol("b"),
                 ],
                 "<root>/packages/root/ignored-exception.js" => vec![
-                    symbol("exception", UsedTag::default()),
+                    symbol("exception"),
                 ]
             ),
+            extra_symbol_tags: amap!(
+                "<root>/packages/root/ignored-unused.js" => vec![
+                    tagged_symbol("a", UsedTag::FROM_IGNORED),
+                    tagged_symbol("b", UsedTag::FROM_IGNORED),
+                ]
+            ),
+            ..Default::default()
         },
     );
 }
@@ -327,8 +389,77 @@ fn test_non_root_root_path() {
             ..Default::default()
         },
         UnusedFinderReport {
-            unused_files: vec![],
-            unused_symbols: bmap![],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_test_pattern() {
+    // Tests that the package traversal works when there is a non-root "root" path.
+    let tmpdir = test_tmpdir!(
+        "search_root/packages/utils/testUtils.js" => r#"
+            export const testSymbol = "testSymbol";
+        "#,
+        "search_root/packages/__tests__/myTest.js" => r#"
+            import * as utils from "../utils/testUtils";
+        "#
+    );
+
+    run_unused_test(
+        &tmpdir,
+        UnusedFinderConfig {
+            repo_root: tmpdir.root().to_string_lossy().to_string(),
+            root_paths: vec!["search_root".to_string()],
+            test_files: vec!["**/__tests__/*Test.js"]
+                .into_iter()
+                .map(glob::Pattern::new)
+                .collect::<Result<Vec<glob::Pattern>, glob::PatternError>>()
+                .unwrap(),
+            ..Default::default()
+        },
+        UnusedFinderReport {
+            extra_symbol_tags: amap!(
+                "<root>/search_root/packages/utils/testUtils.js" => vec![
+                    tagged_symbol("testSymbol", UsedTag::FROM_TEST),
+                ]
+            ),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn test_relative_test_pattern() {
+    // Tests that the package traversal works when there is a non-root "root" path.
+    let tmpdir = test_tmpdir!(
+        "search_root/packages/test-utils/testUtils.js" => r#"
+            export const testSymbol = "testSymbol";
+        "#,
+        "search_root/tests/myTest.js" => r#"
+            import * as utils from "../packages/test-utils/testUtils";
+        "#
+    );
+
+    run_unused_test(
+        &tmpdir,
+        UnusedFinderConfig {
+            repo_root: tmpdir.root().to_string_lossy().to_string(),
+            root_paths: vec!["search_root".to_string()],
+            test_files: vec!["search_root/tests/**"]
+                .into_iter()
+                .map(glob::Pattern::new)
+                .collect::<Result<Vec<glob::Pattern>, glob::PatternError>>()
+                .unwrap(),
+            ..Default::default()
+        },
+        UnusedFinderReport {
+            extra_symbol_tags: amap!(
+                "<root>/search_root/packages/test-utils/testUtils.js" => vec![
+                    tagged_symbol("testSymbol", UsedTag::FROM_TEST),
+                ]
+            ),
+            ..Default::default()
         },
     );
 }

--- a/crates/unused_finder/src/unused_finder.rs
+++ b/crates/unused_finder/src/unused_finder.rs
@@ -3,11 +3,12 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     cfg::{UnusedFinderConfig, UnusedFinderJSONConfig},
-    graph::{Graph, UsedTag},
+    graph::Graph,
     ignore_file::IgnoreFile,
     logger::Logger,
     parse::{get_file_import_export_info, ExportedSymbol},
     report::UnusedFinderReport,
+    tag::UsedTag,
     walk::{walk_src_files, RepoPackages, WalkedFiles},
     walked_file::ResolvedSourceFile,
 };
@@ -353,7 +354,6 @@ impl UnusedFinder {
             )
             .map_err(JsErr::generic_failure)?;
 
-<<<<<<< HEAD
         let test_entrypoints = self.get_test_files();
         logger.log(format!(
             "Starting {} graph traversal with {} entrypoints",
@@ -385,19 +385,6 @@ impl UnusedFinder {
             }
         }
 
-||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
-=======
-        let test_entrypoints = self.get_test_files();
-        logger.log(format!(
-            "Starting {} graph traversal with {} entrypoints",
-            UsedTag::FROM_TEST,
-            test_entrypoints.len(),
-        ));
-        graph
-            .traverse_bfs(&logger, test_entrypoints, vec![], UsedTag::FROM_TEST)
-            .map_err(JsErr::generic_failure)?;
-
->>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
         Ok(UnusedFinderResult::new(graph))
     }
 
@@ -414,7 +401,7 @@ impl UnusedFinder {
             .par_iter()
             .filter_map(|(file_path, source_file)| -> Option<&Path> {
                 let export = self.is_entry_package_export(&logger, file_path, source_file);
-                if export || self.is_file_ignored(file_path) {
+                if export {
                     Some(file_path)
                 } else {
                     None
@@ -474,33 +461,7 @@ impl UnusedFinder {
             .unwrap_or(false)
     }
 
-<<<<<<< HEAD
-    fn get_test_files(&self) -> Vec<PathBuf> {
-        // get the list of files that match the test file patterns
-        self.last_walk_result
-            .source_files
-            .par_iter()
-            .filter_map(|(file_path, _)| {
-                if self
-                    .config
-                    .test_file_patterns
-                    .iter()
-                    .any(|pattern| pattern.matches_path(file_path))
-                {
-                    Some(file_path.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    fn get_ignored_files(&self) -> Vec<PathBuf> {
-||||||| parent of 1b97a00 (unused_finder: track test files, return tagged symbols)
-    fn get_ignored_files(&self) -> Vec<PathBuf> {
-=======
     fn get_ignored_files(&self) -> Vec<&Path> {
->>>>>>> 1b97a00 (unused_finder: track test files, return tagged symbols)
         // TODO: this is n^2, which is bad! Could build a treemap of ignore files?
         self.last_walk_result
             .source_files

--- a/crates/unused_finder_napi/src/lib.rs
+++ b/crates/unused_finder_napi/src/lib.rs
@@ -74,7 +74,6 @@ impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
             report_exported_symbols: val.report_exported_symbols,
             entry_packages: val.entry_packages,
             allow_unused_types: val.allow_unused_types,
-            test_file_patterns: val.test_file_patterns,
             test_files: val.test_files.unwrap_or_default(),
         }
     }

--- a/crates/unused_finder_napi/src/lib.rs
+++ b/crates/unused_finder_napi/src/lib.rs
@@ -56,6 +56,13 @@ pub struct UnusedFinderJSONConfig {
     /// from the list of unused files
     #[serde(default)]
     pub test_file_patterns: Vec<String>,
+    /// List of glob patterns to mark as "tests".
+    /// These files will be marked as used, and all of their transitive
+    /// dependencies will also be marked as used
+    ///
+    /// glob patterns are matched against the relative file path from the
+    /// root of the repository
+    pub test_files: Option<Vec<String>>,
 }
 
 impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
@@ -68,6 +75,7 @@ impl From<UnusedFinderJSONConfig> for unused_finder::UnusedFinderJSONConfig {
             entry_packages: val.entry_packages,
             allow_unused_types: val.allow_unused_types,
             test_file_patterns: val.test_file_patterns,
+            test_files: val.test_files.unwrap_or_default(),
         }
     }
 }
@@ -81,6 +89,8 @@ pub enum UsedTagEnum {
     Ignored,
     #[serde(rename = "type-only")]
     TypeOnly,
+    #[serde(rename = "test")]
+    Test,
 }
 
 impl From<unused_finder::UsedTagEnum> for UsedTagEnum {
@@ -89,6 +99,7 @@ impl From<unused_finder::UsedTagEnum> for UsedTagEnum {
             unused_finder::UsedTagEnum::Entry => UsedTagEnum::Entry,
             unused_finder::UsedTagEnum::Ignored => UsedTagEnum::Ignored,
             unused_finder::UsedTagEnum::TypeOnly => UsedTagEnum::TypeOnly,
+            unused_finder::UsedTagEnum::Test => UsedTagEnum::Test,
         }
     }
 }
@@ -100,7 +111,6 @@ pub struct SymbolReport {
     pub id: String,
     pub start: u32,
     pub end: u32,
-    pub tags: Option<Vec<UsedTagEnum>>,
 }
 
 impl From<unused_finder::SymbolReport> for SymbolReport {
@@ -109,9 +119,22 @@ impl From<unused_finder::SymbolReport> for SymbolReport {
             id: val.id,
             start: val.start,
             end: val.end,
-            tags: val
-                .tags
-                .map(|tags| tags.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Ord, PartialOrd, Eq, Serialize, Deserialize)]
+#[napi(object)]
+pub struct SymbolReportWithTags {
+    pub symbol: SymbolReport,
+    pub tags: Vec<UsedTagEnum>,
+}
+
+impl From<unused_finder::SymbolReportWithTags> for SymbolReportWithTags {
+    fn from(val: unused_finder::SymbolReportWithTags) -> Self {
+        SymbolReportWithTags {
+            symbol: val.symbol.into(),
+            tags: val.tags.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -126,6 +149,8 @@ pub struct UnusedFinderReport {
     // note that this intentionally uses a std HashMap type to guarantee napi
     // compatibility
     pub unused_symbols: HashMap<String, Vec<SymbolReport>>,
+    pub extra_file_tags: HashMap<String, Vec<UsedTagEnum>>,
+    pub extra_symbol_tags: HashMap<String, Vec<SymbolReportWithTags>>,
 }
 
 impl From<unused_finder::UnusedFinderReport> for UnusedFinderReport {
@@ -134,6 +159,16 @@ impl From<unused_finder::UnusedFinderReport> for UnusedFinderReport {
             unused_files: val.unused_files,
             unused_symbols: val
                 .unused_symbols
+                .into_iter()
+                .map(|(k, v)| (k, v.into_iter().map(Into::into).collect()))
+                .collect(),
+            extra_file_tags: val
+                .extra_file_tags
+                .into_iter()
+                .map(|(k, v)| (k, v.into_iter().map(Into::into).collect()))
+                .collect(),
+            extra_symbol_tags: val
+                .extra_symbol_tags
                 .into_iter()
                 .map(|(k, v)| (k, v.into_iter().map(Into::into).collect()))
                 .collect(),


### PR DESCRIPTION
This returns info on ignored files in the `report`. The intent here is to also make it possible for the consumer to show information on files that are only used in tests.
