### PR TITLE
Refactor `unused_finder/logger` into standalone package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,11 +1068,8 @@ dependencies = [
 name = "logger_console"
 version = "0.2.0"
 dependencies = [
- "js_err_napi",
  "logger",
  "napi",
- "napi-derive",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "logger"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "logger_console"
+version = "0.2.0"
+dependencies = [
+ "js_err_napi",
+ "logger",
+ "napi",
+ "napi-derive",
+ "serde",
+]
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2724,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "logger",
  "parking_lot",
  "rstack-self",
  "serde-hjson",
@@ -2727,6 +2746,7 @@ dependencies = [
  "import_resolver",
  "itertools 0.13.0",
  "js_err",
+ "logger",
  "packagejson",
  "packagejson_exports",
  "path-clean",
@@ -2757,6 +2777,8 @@ dependencies = [
  "anyhow",
  "js_err",
  "js_err_napi",
+ "logger",
+ "logger_console",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,8 @@ regex = "1"
 relative-path = "1.7.2"
 serde = { version = "1.0.117", features = ["rc", "derive"] }
 serde_json = "1.0.59"
-swc = "0.284.1"
 swc_common = "0.37.4"
 swc_compiler_base = "0.18.1"
-swc_core = { version = "0.101.3", features = [
-    "ecma_plugin_transform",
-    "ecma_loader_node",
-    "ecma_loader_tsc",
-    "ecma_loader_lru",
-    "ecma_loader_parking_lot",
-] }
 swc_ecma_ast = "0.118.2"
 swc_ecma_loader = "0.49.1"
 swc_ecma_parser = "0.149.0"

--- a/change/@good-fences-api-a7359cc9-6b5b-4355-a1c7-448c715e2197.json
+++ b/change/@good-fences-api-a7359cc9-6b5b-4355-a1c7-448c715e2197.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "refactor logger from unused_finder into own package",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/crates/logger/Cargo.toml
+++ b/crates/logger/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "logger"
+version = "0.2.0"
+authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+anyhow.workspace = true

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -1,5 +1,7 @@
 use std::sync::Mutex;
 
+use anyhow::anyhow;
+
 pub trait Logger: Send + Sync + Clone {
     fn log(&self, message: impl Into<String>);
 }

--- a/crates/logger_console/Cargo.toml
+++ b/crates/logger_console/Cargo.toml
@@ -1,0 +1,16 @@
+
+[package]
+name = "logger_console"
+version = "0.2.0"
+authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+js_err_napi = { version = "0.2.0", path = "../js_err_napi" }
+logger = { version = "0.2.0", path = "../logger" }
+napi.workspace = true
+napi-derive.workspace = true
+serde.workspace = true

--- a/crates/logger_console/Cargo.toml
+++ b/crates/logger_console/Cargo.toml
@@ -9,8 +9,5 @@ edition = "2018"
 crate-type = ["lib"]
 
 [dependencies]
-js_err_napi = { version = "0.2.0", path = "../js_err_napi" }
 logger = { version = "0.2.0", path = "../logger" }
 napi.workspace = true
-napi-derive.workspace = true
-serde.workspace = true

--- a/crates/logger_console/src/lib.rs
+++ b/crates/logger_console/src/lib.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use napi::{
+    threadsafe_function::{
+        ErrorStrategy::{self},
+        ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+    },
+    JsFunction, JsObject, Result, Status,
+};
+
+use logger::Logger;
+
+#[derive(Clone)]
+pub struct ConsoleLogger {
+    logfn: Arc<ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>>,
+}
+
+impl ConsoleLogger {
+    pub fn new(console: JsObject) -> Result<Self> {
+        let logfn = console.get_named_property::<JsFunction>("log")?;
+        Ok(Self {
+            logfn: Arc::new(logfn.create_threadsafe_function(
+                // allow queueing console responses?
+                100,
+                |ctx: ThreadSafeCallContext<String>| {
+                    let js_str = ctx.env.create_string(&ctx.value)?;
+                    // return as an argv array
+                    Ok(vec![js_str])
+                },
+            )?),
+        })
+    }
+}
+
+impl Logger for ConsoleLogger {
+    fn log(&self, message: impl Into<String>) {
+        let message_string: String = message.into();
+        let status = self
+            .logfn
+            .call(Ok(message_string), ThreadsafeFunctionCallMode::Blocking);
+        match status {
+            Status::Ok => {}
+            _ => {
+                eprintln!();
+                panic!("Error calling console.log from Rust. Unexpected threadsafe function call mode {}", status);
+            }
+        }
+    }
+}

--- a/crates/unused_bin/Cargo.toml
+++ b/crates/unused_bin/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 parking_lot.workspace = true
 rstack-self = { version = "0.3.0", default-features = false, optional = true }
 serde-hjson = "1.1.0"
+logger = { version = "0.2.0", path = "../logger" }
 
 [features]
 default = []

--- a/crates/unused_bin/src/main.rs
+++ b/crates/unused_bin/src/main.rs
@@ -2,11 +2,9 @@ extern crate unused_finder;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use logger::{Logger, StdioLogger};
 use std::{convert::TryInto, env, fs, path::Path};
-use unused_finder::{
-    logger::{Logger, StdioLogger},
-    UnusedFinderConfig,
-};
+use unused_finder::UnusedFinderConfig;
 
 #[derive(Parser, Debug)]
 struct CliArgs {

--- a/crates/unused_finder/Cargo.toml
+++ b/crates/unused_finder/Cargo.toml
@@ -38,6 +38,7 @@ abspath = { version = "0.2.0", path = "../abspath" }
 itertools = "0.13.0"
 debug_print = "1.0.0"
 schemars.workspace = true
+logger = { version = "0.2.0", path = "../logger" }
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/crates/unused_finder/src/graph.rs
+++ b/crates/unused_finder/src/graph.rs
@@ -6,11 +6,11 @@ use anyhow::Result;
 use rayon::prelude::*;
 
 use crate::{
-    logger::Logger,
     parse::{ExportedSymbol, ResolvedImportExportInfo},
     tag::UsedTag,
     walked_file::ResolvedSourceFile,
 };
+use logger::Logger;
 
 // graph node used to represent a file during the "used file" walk
 #[derive(Debug, Clone, Default)]

--- a/crates/unused_finder/src/lib.rs
+++ b/crates/unused_finder/src/lib.rs
@@ -15,7 +15,6 @@ extern crate test_tmpdir;
 mod cfg;
 mod graph;
 mod ignore_file;
-pub mod logger;
 mod parse;
 mod report;
 mod tag;

--- a/crates/unused_finder/src/test.rs
+++ b/crates/unused_finder/src/test.rs
@@ -5,7 +5,7 @@ use path_slash::PathBufExt;
 use test_tmpdir::{amap, test_tmpdir};
 
 use crate::{
-    cfg::package_match_rules::PackageMatchRules, logger, report::SymbolReport, tag::UsedTag,
+    cfg::package_match_rules::PackageMatchRules, report::SymbolReport, tag::UsedTag,
     SymbolReportWithTags, UnusedFinder, UnusedFinderConfig, UnusedFinderReport,
 };
 

--- a/crates/unused_finder/src/unused_finder.rs
+++ b/crates/unused_finder/src/unused_finder.rs
@@ -5,7 +5,6 @@ use crate::{
     cfg::{UnusedFinderConfig, UnusedFinderJSONConfig},
     graph::Graph,
     ignore_file::IgnoreFile,
-    logger::Logger,
     parse::{get_file_import_export_info, ExportedSymbol},
     report::UnusedFinderReport,
     tag::UsedTag,
@@ -21,6 +20,7 @@ use import_resolver::swc_resolver::{
     MonorepoResolver,
 };
 use js_err::JsErr;
+use logger::Logger;
 use rayon::{iter::Either, prelude::*};
 use swc_ecma_loader::{resolve::Resolve, TargetEnv};
 

--- a/crates/unused_finder/src/walk.rs
+++ b/crates/unused_finder/src/walk.rs
@@ -1,5 +1,4 @@
 use crate::ignore_file::IgnoreFile;
-use crate::logger::Logger;
 use crate::parse::exports_visitor_runner::SourceFileParseError;
 use crate::parse::{get_file_import_export_info, RawImportExportInfo};
 use crate::walked_file::{WalkedPackage, WalkedSourceFile};
@@ -7,6 +6,7 @@ use ahashmap::AHashMap;
 use anyhow::Context;
 use ignore::overrides::OverrideBuilder;
 use ignore::DirEntry;
+use logger::Logger;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use std::ffi::OsStr;
@@ -401,7 +401,7 @@ fn split_errs<A, B>(x: Result<A, B>) -> Either<A, B> {
 
 #[cfg(test)]
 mod test {
-    use crate::logger::StdioLogger;
+    use logger::StdioLogger;
 
     use super::*;
     use test_tmpdir::test_tmpdir;

--- a/crates/unused_finder_napi/Cargo.toml
+++ b/crates/unused_finder_napi/Cargo.toml
@@ -17,6 +17,8 @@ napi-derive.workspace = true
 unused_finder = { version = "0.2.0", path = "../unused_finder" }
 serde.workspace = true
 js_err_napi = { version = "0.2.0", path = "../js_err_napi" }
+logger_console = { version = "0.2.0", path = "../logger_console" }
+logger = { version = "0.2.0", path = "../logger" }
 
 [build-dependencies]
 napi-build = "2.0.1"


### PR DESCRIPTION
This is so it can be compiled separately. In the future, it may be referenced from other packages that want to do logging without creating dependency cyles.