### PR TITLE
Remove redundant test pattern

### DIFF
--- a/change/@good-fences-api-a7d88fdc-f981-44c7-9d08-98ac791efdd3.json
+++ b/change/@good-fences-api-a7d88fdc-f981-44c7-9d08-98ac791efdd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove duplicate 'testPathPatterns' config property on the napi interface",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Removes the redundant `testPathPattern` field from the napi unusedFinderConfig, and removes some of the unused serde serialization/deserialization fields from the napi types.