### PR TITLE
Restructure logger to enable `logger_srcfile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "logger_srcfile"
+version = "0.2.0"
+dependencies = [
+ "logger",
+ "swc_common",
+]
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/change/@good-fences-api-6ffba5db-a75b-4958-8cba-3e2dea22fa8b.json
+++ b/change/@good-fences-api-6ffba5db-a75b-4958-8cba-3e2dea22fa8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "internal refactoring of loggers",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -2,8 +2,14 @@ use std::sync::Mutex;
 
 use anyhow::anyhow;
 
-pub trait Logger: Send + Sync + Clone {
+pub trait Logger: Clone {
     fn log(&self, message: impl Into<String>);
+    fn warn(&self, message: impl Into<String>) {
+        self.log(format!("WARN: {}", message.into()));
+    }
+    fn error(&self, message: impl Into<String>) {
+        self.log(format!("ERROR: {}", message.into()));
+    }
 }
 
 impl<T: Logger> Logger for &T {

--- a/crates/logger_srcfile/Cargo.toml
+++ b/crates/logger_srcfile/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "logger_srcfile"
+version = "0.2.0"
+authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+logger = { path = "../logger" }
+swc_common.workspace = true

--- a/crates/logger_srcfile/src/lib.rs
+++ b/crates/logger_srcfile/src/lib.rs
@@ -1,0 +1,81 @@
+use logger::Logger;
+use swc_common::{Loc, SourceMap, Span};
+
+pub trait SrcLogger: Logger {
+    fn src_warn(&self, loc: &Loc, message: impl Into<String>) {
+        self.warn(format!(
+            "{}:{}:{} :: {}",
+            loc.file.name,
+            loc.line,
+            loc.col_display,
+            message.into()
+        ));
+    }
+    fn src_error(&self, loc: &Loc, message: impl Into<String>) {
+        self.error(format!(
+            "{}:{}:{} :: {}",
+            loc.file.name,
+            loc.line,
+            loc.col_display,
+            message.into()
+        ));
+    }
+}
+
+pub trait HasSourceMap {
+    fn source_map(&self) -> &SourceMap;
+}
+
+pub trait SrcFileLogger: Logger + HasSourceMap {
+    fn src_warn(&self, location: &Span, message: impl Into<String>) {
+        let loc = self.source_map().lookup_char_pos(location.lo);
+        self.warn(format!(
+            "{}:{}:{} :: {}",
+            loc.file.name,
+            loc.line,
+            loc.col_display,
+            message.into()
+        ));
+    }
+    fn src_error(&self, location: &Span, message: impl Into<String>) {
+        let loc = self.source_map().lookup_char_pos(location.lo);
+        self.error(format!(
+            "{}:{}:{} :: {}",
+            loc.file.name,
+            loc.line,
+            loc.col_display,
+            message.into()
+        ));
+    }
+}
+
+#[derive(Clone)]
+pub struct WrapFileLogger<'a, TLogger: Logger> {
+    source_map: &'a SourceMap,
+    inner_logger: TLogger,
+}
+impl<'a, TLogger: Logger> WrapFileLogger<'a, TLogger> {
+    pub fn new(source_map: &'a SourceMap, inner_logger: TLogger) -> Self {
+        Self {
+            source_map,
+            inner_logger,
+        }
+    }
+}
+impl<TLogger: Logger> Logger for WrapFileLogger<'_, TLogger> {
+    fn log(&self, message: impl Into<String>) {
+        self.inner_logger.log(message);
+    }
+    fn error(&self, message: impl Into<String>) {
+        self.inner_logger.error(message);
+    }
+    fn warn(&self, message: impl Into<String>) {
+        self.inner_logger.warn(message);
+    }
+}
+impl<TLogger: Logger> HasSourceMap for WrapFileLogger<'_, TLogger> {
+    fn source_map(&self) -> &SourceMap {
+        self.source_map
+    }
+}
+impl<TLogger: Logger> SrcFileLogger for WrapFileLogger<'_, TLogger> {}

--- a/crates/unused_finder/src/lib.rs
+++ b/crates/unused_finder/src/lib.rs
@@ -31,7 +31,7 @@ pub use tag::UsedTagEnum;
 pub use unused_finder::{UnusedFinder, UnusedFinderResult};
 
 pub fn find_unused_items(
-    logger: impl logger::Logger,
+    logger: impl logger::Logger + Sync,
     config: UnusedFinderJSONConfig,
 ) -> Result<UnusedFinderReport, js_err::JsErr> {
     let mut finder = UnusedFinder::new_from_json_config(&logger, config)


### PR DESCRIPTION
The overall goal of this change is to support a "sub-trait" of `logger`
that adds some src-file logging methods associated against a given
logging.

This will be used to trace issues with src files while e.g. parsing or
interpreting the structure of source files. As part of this change, the
`Sync` requirement of logger had to be dropped.
This is because the src file informatio nwe get from `swc` is
necessarially non-`Sync`/`Send`.