### PR TITLE
publish.yml: dedup the default deploy platforms

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,15 +98,9 @@ jobs:
           git tag "v$PACKAGE_VERSION"
           git push origin main --tags
 
-          # Required to do github releasing from napi & prep `optionalDependencies` in package.json
-          # for final publish
-          yarn prepublishOnly
-
-          # show the content about to be published
-          tree
-
-          # Publish all packages 
-          yarn npm publish --tag "latest" --access public --tolerate-republish
+          # dependency packages are published via "npm prepublishOnly"
+          # which runs the napi-rs cli under the hood.
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/change/@good-fences-api-8147c32a-887f-40ad-9631-2868257e3b19.json
+++ b/change/@good-fences-api-8147c32a-887f-40ad-9631-2868257e3b19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "avoid duplicate publishing in napi prepublish from default platforms",
+  "packageName": "@good-fences/api",
+  "email": "Maxwell.HuangHobbs@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "napi": {
     "name": "@good-fences",
     "triples": {
+      "defaults": false,
       "additional": [
         "aarch64-apple-darwin",
         "aarch64-pc-windows-msvc",


### PR DESCRIPTION
- replaces the yarn workspace publish with `napi prepublish`
- removes the default platforms from the napi platforms array (was causing redundant publishing)