### PR TITLE
devcontainer.json: use slirp4netns to boot offline

### DIFF
--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -63,6 +63,17 @@
         // these labels are required in order to allow the container user
         // to access the various container mounts.
         "--userns=keep-id",
-        "--security-opt=label=disable"
+        "--security-opt=label=disable",
+        // This is a workaround to allow using the container when
+        // offline.
+        //
+        // Note that this actually degrades network peformance for the container,
+        // so it should be removed once the fix for pasta/podman is eventually
+        // implemented.
+        // See: https://github.com/containers/podman/issues/23566
+        //
+        // Note that this requires the host system to have slirp4netns installed
+        // on fedora you can do this via `dnf install slirp4netns`
+        "--network=slirp4netns"
     ]
 }

--- a/.devcontainer/podman/patch.json
+++ b/.devcontainer/podman/patch.json
@@ -3,6 +3,7 @@
     "build.dockerfile": "../default/container/Dockerfile",
     "runArgs": [
         "--userns=keep-id",
-        "--security-opt=label=disable"
+        "--security-opt=label=disable",
+        "--network=slirp4netns"
     ]
 }

--- a/change/@good-fences-api-0596ce17-9105-4394-83a1-ffb3cce67733.json
+++ b/change/@good-fences-api-0596ce17-9105-4394-83a1-ffb3cce67733.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "devcontainer.json: use slirp4netns to boot offline",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
replaces the default (pasta) with slirp4netns in the podman container.

This is a workaround to allow using the container when offline.

Note that this actually degrades network peformance for the container,
so it should be removed once the fix for pasta/podman is eventually implemented.
See: https://github.com/containers/podman/issues/23566

Note that this requires the host system to have slirp4netns installed
on fedora you can do this via `dnf install slirp4netns`