### PR TITLE
 multi_err: new crate for combining errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutli_err"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "napi"
 version = "2.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mutli_err"
+name = "multi_err"
 version = "0.2.0"
 dependencies = [
  "anyhow",

--- a/change/@good-fences-api-d1c12010-0e3a-4d4d-96a9-5a84ae2d5558.json
+++ b/change/@good-fences-api-d1c12010-0e3a-4d4d-96a9-5a84ae2d5558.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "multi_err: new crate for combining errors",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/crates/multi_err/Cargo.toml
+++ b/crates/multi_err/Cargo.toml
@@ -10,8 +10,6 @@ crate-type = ["lib"]
 
 [dependencies]
 anyhow.workspace = true
-logger = { path = "../logger" }
-swc_common.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/multi_err/Cargo.toml
+++ b/crates/multi_err/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mutli_err"
+version = "0.2.0"
+authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
+edition = "2018"
+description = "A library for handling multiple errors"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+anyhow.workspace = true
+logger = { path = "../logger" }
+swc_common.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/crates/multi_err/Cargo.toml
+++ b/crates/multi_err/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mutli_err"
+name = "multi_err"
 version = "0.2.0"
 authors = ["Maxwell Huang-Hobbs <mhuan13@gmail.com>"]
 edition = "2018"

--- a/crates/multi_err/src/lib.rs
+++ b/crates/multi_err/src/lib.rs
@@ -1,0 +1,178 @@
+use std::fmt::Display;
+
+pub struct MultiErr<TErr> {
+    errs: Vec<TErr>,
+}
+
+impl<TErr> MultiErr<TErr> {
+    pub fn new() -> Self {
+        Self { errs: Vec::new() }
+    }
+
+    pub fn add_multi(&mut self, other: MultiErr<TErr>) {
+        self.errs.extend(other.errs);
+    }
+
+    pub fn add_iter(&mut self, other: impl Iterator<Item = TErr>) {
+        self.errs.extend(other);
+    }
+
+    pub fn add_single(&mut self, other: TErr) {
+        self.errs.push(other);
+    }
+
+    // Convenience wrapper for add_multi for unpacking a result tuple
+    pub fn extract<T>(&mut self, other: MultiResult<T, TErr>) -> T {
+        self.add_multi(other.1);
+        other.0
+    }
+
+    // Convenience wrapper for add_multi for unpacking a result tuple
+    pub fn extract_multi<T>(&mut self, other: (T, MultiErr<TErr>)) -> T {
+        self.add_multi(other.1);
+        other.0
+    }
+
+    // Convenience wrapper for add_iter for unpacking a result tuple
+    pub fn extract_iter<T>(&mut self, other: (T, impl Iterator<Item = TErr>)) -> T {
+        self.add_iter(other.1);
+        other.0
+    }
+
+    // Convenience wrapper for add_single for unpacking a result tuple
+    pub fn extract_single<T>(&mut self, other: (T, TErr)) -> T {
+        self.add_single(other.1);
+        other.0
+    }
+
+    pub fn with_value<T>(self, val: T) -> MultiResult<T, TErr> {
+        MultiResult::with_errs(val, self)
+    }
+
+    // converts this mutli error into a result
+    pub fn into_result(self) -> Result<(), Self> {
+        if self.errs.is_empty() {
+            Ok(())
+        } else {
+            Err(self)
+        }
+    }
+}
+impl<TErr> Default for MultiErr<TErr> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<T> From<MultiErr<T>> for Vec<T> {
+    fn from(other: MultiErr<T>) -> Self {
+        other.errs
+    }
+}
+impl<T: Display> MultiErr<T> {
+    fn into_anyhow(self) -> anyhow::Error {
+        if self.errs.len() == 1 {
+            return anyhow::anyhow!("{:#}", self.errs[0]);
+        }
+
+        anyhow::anyhow!(
+            "{} errors:\n  {}",
+            self.errs.len(),
+            self.errs
+                .iter()
+                .enumerate()
+                .map(|(i, e)| format!("{}: {:#}", i + 1, e))
+                .collect::<Vec<String>>()
+                .join("\n  ")
+        )
+    }
+}
+impl<T: Display> From<MultiErr<T>> for anyhow::Error {
+    fn from(other: MultiErr<T>) -> Self {
+        other.into_anyhow()
+    }
+}
+
+pub struct MultiResult<TRes, TErr>(TRes, MultiErr<TErr>);
+impl<TRes, TErr> MultiResult<TRes, TErr> {
+    pub fn from(val: TRes) -> Self {
+        Self(val, MultiErr::new())
+    }
+    pub fn with_errs(val: TRes, errs: MultiErr<TErr>) -> Self {
+        Self(val, errs)
+    }
+}
+
+impl<TRes, TErr: Display> MultiResult<TRes, TErr> {
+    // converts this mutli error into a result
+    pub fn into_anyhow(self) -> Result<TRes, anyhow::Error> {
+        if self.1.errs.is_empty() {
+            Ok(self.0)
+        } else {
+            Err(self.1.into_anyhow())
+        }
+    }
+}
+
+impl<TRes, TErr, ErrColl: Into<MultiErr<TErr>>> From<(TRes, ErrColl)> for MultiResult<TRes, TErr> {
+    fn from((val, err): (TRes, ErrColl)) -> Self {
+        MultiResult::with_errs(val, err.into())
+    }
+}
+
+impl<TRes, TErr> From<MultiResult<TRes, TErr>> for Result<TRes, MultiErr<TErr>> {
+    fn from(multi_result: MultiResult<TRes, TErr>) -> Self {
+        let (val, multi_errs) = (multi_result.0, multi_result.1);
+        multi_errs.into_result().map(|_| val)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use anyhow::anyhow;
+    use pretty_assertions::assert_eq;
+
+    use crate::MultiErr;
+
+    #[test]
+    fn test_into_anyhow_display_single() {
+        let mut multi_err = MultiErr::new();
+        let e = anyhow!("this is the error").context("this is the context");
+        multi_err.add_single(e);
+
+        let as_str = format!("{:#}", multi_err.into_anyhow());
+        assert_eq!(as_str, "this is the context: this is the error");
+    }
+
+    #[test]
+    fn test_into_anyhow_display_multi() {
+        let mut multi_err = MultiErr::new();
+        multi_err.add_single(anyhow!("this is the first error").context("this is the context"));
+        multi_err.add_single(anyhow!("this is the second error"));
+
+        let as_str = format!("{:#}", multi_err.into_anyhow());
+        assert_eq!(
+            as_str,
+            "2 errors:
+  1: this is the context: this is the first error
+  2: this is the second error"
+        )
+    }
+
+    #[test]
+    fn test_into_anyhow_display_multi_conext_chain() {
+        let mut multi_err = MultiErr::new();
+        multi_err.add_single(anyhow!("this is the first error").context("this is the context"));
+        multi_err.add_single(anyhow!("this is the second error"));
+
+        let as_str = format!(
+            "{:#}",
+            multi_err.into_anyhow().context("this is the outer context")
+        );
+        assert_eq!(
+            as_str,
+            "this is the outer context: 2 errors:
+  1: this is the context: this is the first error
+  2: this is the second error"
+        )
+    }
+}


### PR DESCRIPTION
Adds a convenience crate for combining multiple errors and results from a batch operation