### PR TITLE
.vscode: add missing rust-analyzer extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ms-vscode-remote.remote-containers",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "rust-lang.rust-analyzer"
     ]
 }

--- a/change/@good-fences-api-0e7b8ffa-fb92-4421-9d67-9c7fcfd4fd7b.json
+++ b/change/@good-fences-api-0e7b8ffa-fb92-4421-9d67-9c7fcfd4fd7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": ".vscode: add missing rust-analyzer extension",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
Adds the `rust-analyzer` extension to the workspace's default installed extensions