### PR TITLE
 unused_finder: ensure tagging passes don't overwrite each other 

### DIFF
--- a/change/@good-fences-api-8fcdec71-7be8-41ec-b321-840ea53cc7ec.json
+++ b/change/@good-fences-api-8fcdec71-7be8-41ec-b321-840ea53cc7ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "unused_finder: ensure tagging passes don't overwrite each other",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Ensures that multiple tagging passes over a graph will not overwrite previous tagged values