### PR TITLE
Avoid infinite loops in `export * from` expansion

### DIFF
--- a/.devcontainer/default/container/.gitconfig
+++ b/.devcontainer/default/container/.gitconfig
@@ -1,3 +1,37 @@
+[column]
+        ui = auto
+[branch]
+        sort = -committerdate
+[tag]
+        sort = version:refname
+[init]
+        defaultBranch = main
+[diff]
+        algorithm = histogram
+        colorMoved = plain
+        mnemonicPrefix = true
+        renames = true
+[push]
+        default = simple
+        autoSetupRemote = true
+        followTags = true
+[fetch]
+        prune = true
+        pruneTags = true
+        all = true
+
+[help]
+        autocorrect = prompt
+[commit]
+        verbose = true
+[rerere]
+        enabled = true
+        autoupdate = true
+[rebase]
+        autoSquash = true
+        autoStash = true
+        updateRefs = true
+
 [alias]
     lol = log --oneline --graph
     lola = log --oneline --graph --all

--- a/change/@good-fences-api-d123a39b-a3a3-49f6-b648-2b0ac61df85b.json
+++ b/change/@good-fences-api-d123a39b-a3a3-49f6-b648-2b0ac61df85b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix infinite loops in export * expansion",
+  "packageName": "@good-fences/api",
+  "email": "mhuan13@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/unused_finder/src/parse/data.rs
+++ b/crates/unused_finder/src/parse/data.rs
@@ -205,6 +205,54 @@ impl ResolvedImportExportInfo {
             .chain(re_exports)
             .chain(executed_paths)
     }
+
+    /// Test helper that gets a copy of this ImportExportInfo with all spans
+    /// zeroed.
+    pub fn with_zeroed_spans(&self) -> Self {
+        let exported_ids = self
+            .exported_ids
+            .iter()
+            .map(|(symbol, meta)| {
+                (
+                    symbol.clone(),
+                    ExportedSymbolMetadata {
+                        span: Span::default(),
+                        ..meta.clone()
+                    },
+                )
+            })
+            .collect();
+        let export_from_symbols = self
+            .export_from_symbols
+            .iter()
+            .map(|(path, symbols)| {
+                (
+                    path.clone(),
+                    symbols
+                        .iter()
+                        .map(|(symbol, meta)| {
+                            (
+                                symbol.clone(),
+                                ExportedSymbolMetadata {
+                                    span: Span::default(),
+                                    ..meta.clone()
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        Self {
+            exported_ids,
+            export_from_symbols,
+            imported_symbols: self.imported_symbols.clone(),
+            require_paths: self.require_paths.clone(),
+            imported_paths: self.imported_paths.clone(),
+            executed_paths: self.executed_paths.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash, Default)]

--- a/crates/unused_finder/src/unused_finder.rs
+++ b/crates/unused_finder/src/unused_finder.rs
@@ -180,7 +180,7 @@ impl SourceFiles {
                     Some(file) => file,
                     None => {
                         logger.warn(format!(
-                            "Could not expand 'export * from '{imported}' statement. '{imported}' is probably an export to an external file or module, which we can't check safely",
+                            "Could not expand 'export * from '{imported}' in expanded exports of {current_path:#?}. '{imported}' is probably an external module, which we can't check safely",
                             imported=imported_path.display(),
                         ));
                         continue;
@@ -1233,6 +1233,8 @@ mod test {
                 .with_zeroed_spans(),
             ResolvedImportExportInfo {
                 executed_paths: aset! {
+                    tmpdir.root_join("search_root/transitive-1.js"),
+                    tmpdir.root_join("search_root/transitive-2.js"),
                     tmpdir.root_join("search_root/side-effect.js")
                 },
                 export_from_symbols: amap2! {

--- a/crates/unused_finder/src/unused_finder.rs
+++ b/crates/unused_finder/src/unused_finder.rs
@@ -150,23 +150,23 @@ impl SourceFiles {
                 Vec::<(PathBuf, ReExportedSymbol, ExportedSymbolMetadata)>::new();
             let mut delete_star_exports = Vec::<PathBuf>::new();
 
-            println!("expanding frontier file {}", current_path.display());
+            // println!("expanding frontier file {}", current_path.display());
             for (imported_path, re_exports) in current_export_from_symbols.iter() {
                 // skip imports back to the current path to break cycles
                 let visited_key = (current_path.clone(), imported_path.clone());
                 if !visited.insert(visited_key) {
-                    println!(
-                        "skipping already expanded re_exports ({} -> {})",
-                        current_path.display(),
-                        imported_path.display()
-                    );
+                    // println!(
+                    //     "skipping already expanded re_exports ({} -> {})",
+                    //     current_path.display(),
+                    //     imported_path.display()
+                    // );
                     continue;
                 }
-                println!(
-                    "expanding frontier re_exports from {} -> {}",
-                    current_path.display(),
-                    imported_path.display()
-                );
+                // println!(
+                //     "expanding frontier re_exports from {} -> {}",
+                //     current_path.display(),
+                //     imported_path.display()
+                // );
 
                 // can't expand export * from external
                 let target_file = match source_files.get(imported_path) {
@@ -246,18 +246,18 @@ impl SourceFiles {
                     .import_export_info
                     .export_from_symbols
                     .remove(&imported_path);
-                println!(
-                    "deferred effect import: {:#?} -> {:#?}",
-                    current_path, imported_path
-                );
+                // println!(
+                //     "deferred effect import: {:#?} -> {:#?}",
+                //     current_path, imported_path
+                // );
                 deferred_files_entry.insert(imported_path);
             }
             // Add indirect effect exports we already recursively expanded.
             for indirect_entry in indirect_deferred_effect_exports {
-                println!(
-                    "indirect deferred effect import: {:#?} -> {:#?}",
-                    current_path, indirect_entry
-                );
+                // println!(
+                //     "indirect deferred effect import: {:#?} -> {:#?}",
+                //     current_path, indirect_entry
+                // );
                 if current_path != indirect_entry {
                     deferred_files_entry.insert(indirect_entry);
                 }
@@ -288,7 +288,7 @@ impl SourceFiles {
             }
         }
         // apply deferred effect imports
-        println!("deferred effect imports: {:#?}", deferred_effect_imports);
+        // println!("deferred effect imports: {:#?}", deferred_effect_imports);
         for (path, effect_imports) in deferred_effect_imports {
             let file = source_files.get_mut(&path).unwrap();
             for effect_import in effect_imports {


### PR DESCRIPTION
- Avoids infinite loop while expanding unresolved external import
- Avoids infinite loop while expanding cyclical imports
- Adds maximum caps to all frontier traversals in graph generation and export * expansion