### PR TITLE
fix: force-link dependent crate symbols on macOS to preserve NAPI exp…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,13 +69,32 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
       - name: display artifacts
         run: ls -R artifacts
+      - name: pack platform tarballs
+        shell: bash
+        run: |
+          VERSION=$(jq -r .version package.json)
+          mkdir -p tarballs
+          for dir in npm/*/; do
+            PLATFORM=$(basename "$dir")
+            PKG_JSON="$dir/package.json"
+            # find matching .node binary
+            BINARY=$(jq -r .main "$PKG_JSON")
+            if [ -f "artifacts/$BINARY" ]; then
+              cp "artifacts/$BINARY" "$dir/"
+              (cd "$dir" && npm pack --pack-destination ../../tarballs)
+            fi
+          done
+          ls tarballs/
       - uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*
+          files: |
+            artifacts/*
+            tarballs/*.tgz
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,11 +79,12 @@ jobs:
       - name: pack platform tarballs
         shell: bash
         run: |
-          VERSION=$(jq -r .version package.json)
+          VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p tarballs
           for dir in npm/*/; do
-            PLATFORM=$(basename "$dir")
             PKG_JSON="$dir/package.json"
+            # inject version from git tag
+            jq --arg v "$VERSION" '.version = $v' "$PKG_JSON" > "$PKG_JSON.tmp" && mv "$PKG_JSON.tmp" "$PKG_JSON"
             # find matching .node binary
             BINARY=$(jq -r .main "$PKG_JSON")
             if [ -f "artifacts/$BINARY" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           - host: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             packages: gcc-aarch64-linux-gnu
-          - host: macos-13
+          - host: macos-latest
             target: x86_64-apple-darwin
           - host: macos-latest
             target: aarch64-apple-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,108 +1,81 @@
 name: publish artifacts
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
   workflow_dispatch:
-concurrency:
-  group: publish-${{ github.workflow }}
 permissions:
   contents: write
 jobs:
-  tests:
-    uses: Adjective-Object/good-fences-rs-core/.github/workflows/unittest.yml@main
-  publish:
-    needs:
-      - tests
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            js-files: true
+          - host: ubuntu-24.04
+            target: aarch64-unknown-linux-gnu
+            packages: gcc-aarch64-linux-gnu
+          - host: macos-13
+            target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+    name: build ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          fetch-depth: 0
-          token: ${{ secrets.BEACHBALL_PUSH_PAT }}
-      - name: pull x86_64-unknown-linux-gnu
-        uses: actions/download-artifact@v4
+          toolchain: nightly-2024-10-25
+          targets: ${{ matrix.settings.target }}
+      - uses: actions/cache@v4
         with:
-          name: bindings-x86_64-unknown-linux-gnu
-      - name: pull aarch64-unknown-linux-gnu
-        uses: actions/download-artifact@v4
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .cargo-cache
+            target/
+          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
+      - name: install packages
+        if: ${{ matrix.settings.packages }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.settings.packages }}
+      - name: napi build
+        run: yarn install && yarn build --target ${{ matrix.settings.target }}
+      - uses: actions/upload-artifact@v4
         with:
-          name: bindings-aarch64-unknown-linux-gnu
-      - name: pull x86_64-apple-darwin
-        uses: actions/download-artifact@v4
-        with:
-          name: bindings-x86_64-apple-darwin
-      - name: pull aarch64-apple-darwin
-        uses: actions/download-artifact@v4
-        with:
-          name: bindings-aarch64-apple-darwin
-      - name: pull x86_64-pc-windows-msvc
-        uses: actions/download-artifact@v4
-        with:
-          name: bindings-x86_64-pc-windows-msvc
-      - name: pull aarch64-pc-windows-msvc
-        uses: actions/download-artifact@v4
-        with:
-          name: bindings-aarch64-pc-windows-msvc
-      - name: pull js files
-        uses: actions/download-artifact@v4
+          name: bindings-${{ matrix.settings.target }}
+          path: ./*.node
+          if-no-files-found: error
+      - name: upload js files
+        if: ${{ matrix.settings.js-files }}
+        uses: actions/upload-artifact@v4
         with:
           name: js-files
-      - name: display artifacts
-        run: ls -R
-      - name: install deps
-        run: yarn install
-      - name: copy artifacts
-        run: |
-          mkdir artifacts
-          cp *.node artifacts
-          yarn artifacts
-      - uses: actions/setup-node@v4
+          if-no-files-found: error
+          path: |
+            index.js
+            index.d.ts
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
         with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: Check changes
-        id: check_changes
-        run: |
-          git remote set-url origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-          OLD_PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
-
-          # Generate changes from beachball, including package.json version bump
-          yarn beachball bump
-
-          # check for changes
-          PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
-          if [ "$OLD_PACKAGE_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "HAS_CHANGES=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "HAS_CHANGES=false" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-      - name: Publish
-        if: ${{ steps.check_changes.outputs.HAS_CHANGES == 'true' }}
-        run: |
-          set -exo pipefail
-
-          git config user.email "mhuan13@gmail.com"
-          git config user.name "$GITHUB_ACTOR"
-
-          # sync new package verson to napi-managed packages (ignored by beachball)
-          yarn napi version -c package.json
-
-          # Commit changes and tag with a version
-          PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
-          git commit -am "v$PACKAGE_VERSION"
-
-          # Push updated branch to git main branch
-          git tag "v$PACKAGE_VERSION"
-          git push origin main --tags
-
-          # dependency packages are published via "npm prepublishOnly"
-          # which runs the napi-rs cli under the hood.
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.BEACHBALL_PUSH_PAT }}
-          GITHUB_ACTOR: autobot
+          path: artifacts
+          merge-multiple: true
+      - name: display artifacts
+        run: ls -R artifacts
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ split-debuginfo = "packed"
 # optimises for speed over size
 opt-level = "s"
 # run link-time optimisation for release builds.
-# This will make the final binary take longer to build, but can result in faster, samller  code.
+# This will make the final binary take longer to build, but can result in faster, smaller code.
 lto = true
 # on panic, abort instead of unwinding. This allows us to avoid gimli (rust's stack unwinder
 # but also makes debugging from stack traces harder.

--- a/change/@good-fences-api-bf16202c-7095-4ada-af2a-1454b1413944.json
+++ b/change/@good-fences-api-bf16202c-7095-4ada-af2a-1454b1413944.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: use thin LTO to preserve NAPI #[ctor] constructors on macOS",
+  "packageName": "@good-fences/api",
+  "email": "michalbiesek@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/good_fences/src/evaluate_fences.rs
+++ b/crates/good_fences/src/evaluate_fences.rs
@@ -489,6 +489,7 @@ mod test {
                 paths: HashMap::new(),
                 base_url: Option::None,
             },
+            exclude: Vec::new(),
         };
     }
 

--- a/crates/good_fences/src/good_fences_runner.rs
+++ b/crates/good_fences/src/good_fences_runner.rs
@@ -3,6 +3,7 @@ use crate::evaluate_fences::{evaluate_fences, FenceEvaluationResult};
 use crate::fence::Fence;
 use crate::fence_collection::FenceCollection;
 use crate::walk_dirs::{discover_fences_and_files, ExternalFences, SourceFile, WalkFileData};
+use glob::Pattern;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -56,10 +57,23 @@ impl GoodFencesRunner {
             })
             .collect();
 
-        // build sources map
+        // build exclude patterns from tsconfig
+        let exclude_patterns: Vec<Pattern> = tsconfig_paths_json
+            .exclude
+            .iter()
+            .filter_map(|pat| Pattern::new(pat).ok())
+            .collect();
+
+        // build sources map, filtering out excluded files
         let source_file_map: HashMap<String, SourceFile> = HashMap::from_iter(
             sources
                 .into_iter()
+                .filter(|source_file| {
+                    if exclude_patterns.is_empty() {
+                        return true;
+                    }
+                    !exclude_patterns.iter().any(|pat| pat.matches(&source_file.source_file_path))
+                })
                 .map(|source_file| (source_file.source_file_path.clone(), source_file)),
         );
         // println!("source file map: {:#?}", source_file_map);
@@ -217,6 +231,7 @@ mod test {
                         base_url: None,
                         paths: HashMap::new(),
                     },
+                    exclude: vec!["lib".to_owned()],
                 },
                 fence_collection: FenceCollection {
                     fences_map: map!(

--- a/crates/good_fences/src/good_fences_runner.rs
+++ b/crates/good_fences/src/good_fences_runner.rs
@@ -77,7 +77,7 @@ impl GoodFencesRunner {
     }
 
     pub fn find_import_violations(&self) -> FenceEvaluationResult<'_, '_> {
-        println!("Evaluating {} files", self.source_files.keys().len());
+        eprintln!("Evaluating {} files", self.source_files.keys().len());
         let mut evaluation_results = FenceEvaluationResult::new();
 
         let violation_results = self

--- a/crates/good_fences/src/lib.rs
+++ b/crates/good_fences/src/lib.rs
@@ -37,28 +37,6 @@ pub fn good_fences(opts: GoodFencesOptions) -> Vec<GoodFencesResult> {
 
     let eval_results = good_fences_runner.find_import_violations();
 
-    // Print results and statistics
-    if !eval_results.violations.is_empty() {
-        println!("Violations:");
-        eval_results
-            .violations
-            .iter()
-            .for_each(|v| println!("{}", v));
-        println!("Total violations: {}", eval_results.violations.len());
-    }
-
-    if !eval_results.unresolved_files.is_empty() {
-        println!("Unresolved files:",);
-        eval_results
-            .unresolved_files
-            .iter()
-            .for_each(|f| println!("{}", f));
-        println!(
-            "Total unresolved files: {}",
-            eval_results.unresolved_files.len()
-        );
-    }
-
     let mut errors: Vec<GoodFencesResult> = Vec::new();
 
     eval_results.violations.iter().for_each(|v| {

--- a/crates/napi_root/build.rs
+++ b/crates/napi_root/build.rs
@@ -2,4 +2,13 @@ extern crate napi_build;
 
 fn main() {
     napi_build::setup();
+
+    // On macOS, the linker strips #[ctor] static constructors from dependent
+    // rlibs (good_fences_napi, unused_finder_napi) because they appear as dead
+    // code in the final cdylib. Force inclusion of all archive members.
+    // Linux/Windows handle static initializers differently and don't need this.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "macos" || target_os == "ios" {
+        println!("cargo:rustc-link-arg=-Wl,-all_load");
+    }
 }

--- a/crates/tsconfig_paths/src/tsconfig_paths_json.rs
+++ b/crates/tsconfig_paths/src/tsconfig_paths_json.rs
@@ -3,27 +3,55 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::Path;
 use std::vec::Vec;
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Default, Clone)]
 #[serde(rename_all = "camelCase")]
+struct RawTsconfigPathsJson {
+    pub extends: Option<String>,
+    pub compiler_options: Option<TsconfigPathsCompilerOptions>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct TsconfigPathsJson {
     pub compiler_options: TsconfigPathsCompilerOptions,
 }
 
 impl TsconfigPathsJson {
-    // Reads and parses the tsconfig.json at the provided path
     pub fn from_path(tsconfig_path: &str) -> Result<Self, OpenTsConfigError> {
-        let file = match File::open(tsconfig_path) {
-            Ok(f) => f,
-            Err(err) => return Err(OpenTsConfigError::IOError(err)),
-        };
+        Self::resolve(Path::new(tsconfig_path))
+    }
+
+    fn resolve(path: &Path) -> Result<Self, OpenTsConfigError> {
+        let file = File::open(path).map_err(OpenTsConfigError::IOError)?;
         let buf_reader = BufReader::new(file);
-        let tsconfig_paths_json: TsconfigPathsJson = match serde_json::from_reader(buf_reader) {
-            Ok(tsconfig) => tsconfig,
-            Err(e) => return Err(OpenTsConfigError::SerdeError(e)),
+        let raw: RawTsconfigPathsJson =
+            serde_json::from_reader(buf_reader).map_err(OpenTsConfigError::SerdeError)?;
+
+        let base = match &raw.extends {
+            Some(extends_path) => {
+                let parent_dir = path.parent().unwrap_or(Path::new("."));
+                let resolved = parent_dir.join(extends_path);
+                Some(Self::resolve(&resolved)?)
+            }
+            None => None,
         };
-        Ok(tsconfig_paths_json)
+
+        let mut compiler_options = base
+            .map(|b| b.compiler_options)
+            .unwrap_or_default();
+
+        if let Some(overrides) = raw.compiler_options {
+            if overrides.base_url.is_some() {
+                compiler_options.base_url = overrides.base_url;
+            }
+            if !overrides.paths.is_empty() {
+                compiler_options.paths.extend(overrides.paths);
+            }
+        }
+
+        Ok(TsconfigPathsJson { compiler_options })
     }
 }
 
@@ -31,5 +59,6 @@ impl TsconfigPathsJson {
 #[serde(rename_all = "camelCase")]
 pub struct TsconfigPathsCompilerOptions {
     pub base_url: Option<String>,
+    #[serde(default)]
     pub paths: HashMap<String, Vec<String>>,
 }

--- a/crates/tsconfig_paths/src/tsconfig_paths_json.rs
+++ b/crates/tsconfig_paths/src/tsconfig_paths_json.rs
@@ -11,11 +11,14 @@ use std::vec::Vec;
 struct RawTsconfigPathsJson {
     pub extends: Option<String>,
     pub compiler_options: Option<TsconfigPathsCompilerOptions>,
+    #[serde(default)]
+    pub exclude: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct TsconfigPathsJson {
     pub compiler_options: TsconfigPathsCompilerOptions,
+    pub exclude: Vec<String>,
 }
 
 impl TsconfigPathsJson {
@@ -39,7 +42,8 @@ impl TsconfigPathsJson {
         };
 
         let mut compiler_options = base
-            .map(|b| b.compiler_options)
+            .as_ref()
+            .map(|b| b.compiler_options.clone())
             .unwrap_or_default();
 
         if let Some(overrides) = raw.compiler_options {
@@ -51,7 +55,13 @@ impl TsconfigPathsJson {
             }
         }
 
-        Ok(TsconfigPathsJson { compiler_options })
+        // Child exclude overrides base exclude (same as tsc behavior)
+        let exclude = match raw.exclude {
+            Some(exc) => exc,
+            None => base.map(|b| b.exclude).unwrap_or_default(),
+        };
+
+        Ok(TsconfigPathsJson { compiler_options, exclude })
     }
 }
 

--- a/good-fences.js
+++ b/good-fences.js
@@ -12,7 +12,8 @@ const { program } = require('commander');
 program
     .option('-p, --project <string> ', 'tsconfig.json file path, defaults to `./tsconfig.json`', './tsconfig.paths.json')
     .option('-o, --output <string>', 'path to write found violations')
-    .option('--baseUrl <string>', "Overrides `compilerOptions.baseUrl` property read from '--project' argument", '.')
+    .option('--baseUrl <string>', "Overrides `compilerOptions.baseUrl` property read from '--project' argument")
+    .option('-q, --quiet', 'Suppress unresolved file warnings', false)
     .option('--ignoreExternalFences', 'Ignore external fences (e.g. those in `node_modules`)', false)
     .option('--ignoredDirs [pathRegexs...]', 'Directories matching given regular expressions are excluded from fence evaluation (e.g. `--ignoreDirs lib` will not evaluate source files in all dirs named `lib`', [])
     .arguments('<path> [morePaths...]')
@@ -21,25 +22,39 @@ program.parse(process.argv);
 const options = program.opts();
 const args = program.args;
 
-const result = goodFences({
+const opts = {
     paths: args ?? ['packages', 'shared'],
     project: options.project,
-    baseUrl: options.baseUrl,
     errOutputPath: options.output,
     ignoreExternalFences: options.ignoreExternalFences ? 1 : 0,
     ignoredDirs: options.ignoredDirs,
-});
+};
+if (options.baseUrl) {
+    opts.baseUrl = options.baseUrl;
+}
 
+const result = goodFences(opts);
+
+const violations = [];
+const unresolved = [];
 result.forEach(r => {
-    if (r.resultType !== GoodFencesResultType.Violation) {
-        console.log(r.detailedMessage);
-    }
-
     if (r.resultType === GoodFencesResultType.Violation) {
-        console.error(r.detailedMessage);
+        violations.push(r.detailedMessage);
+    } else {
+        unresolved.push(r.detailedMessage);
     }
 });
 
-if (result.find(r => r.resultType === GoodFencesResultType.Violation)) {
+if (violations.length) {
+    console.error(`${violations.length} violation(s) found:\n`);
+    violations.forEach(v => console.error(v));
+}
+
+if (!options.quiet && unresolved.length) {
+    console.log(`\n${unresolved.length} unresolved import(s):\n`);
+    unresolved.forEach(u => console.log(u));
+}
+
+if (violations.length) {
     process.exit(1);
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-arm64",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-arm64",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-x64",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-x64",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-arm64-gnu",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-arm64-gnu",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-x64-gnu",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-x64-gnu",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-arm64-msvc",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "win32"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-arm64-msvc",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-x64-msvc",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-x64-msvc",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api",
-  "version": "0.20.3",
+  "version": "0.20.5",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api",
-  "version": "0.20.0",
+  "version": "0.20.3",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
…orts

The napi_root crate re-exports #[napi] functions from good_fences_napi and unused_finder_napi via `pub use`. However, the #[ctor] static constructors generated by napi-derive to register these functions are private and the macOS linker strips them as dead code from the final cdylib. This causes the native binding to load but export an empty object (goodFences is undefined).

Fix by passing -Wl,-all_load to the macOS linker via build.rs, forcing all symbols from static archives to be included. Linux and Windows handle static initializers differently and don't need this flag.