### PR TITLE
revert: restore beachball workflow and package versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,101 +1,108 @@
 name: publish artifacts
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
   workflow_dispatch:
+concurrency:
+  group: publish-${{ github.workflow }}
 permissions:
   contents: write
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - host: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            js-files: true
-          - host: ubuntu-24.04
-            target: aarch64-unknown-linux-gnu
-            packages: gcc-aarch64-linux-gnu
-          - host: macos-latest
-            target: x86_64-apple-darwin
-          - host: macos-latest
-            target: aarch64-apple-darwin
-          - host: windows-latest
-            target: x86_64-pc-windows-msvc
-          - host: windows-latest
-            target: aarch64-pc-windows-msvc
-    name: build ${{ matrix.settings.target }}
-    runs-on: ${{ matrix.settings.host }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-10-25
-          targets: ${{ matrix.settings.target }}
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo-cache
-            target/
-          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
-      - name: install packages
-        if: ${{ matrix.settings.packages }}
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ${{ matrix.settings.packages }}
-      - name: napi build
-        run: yarn install && yarn build --target ${{ matrix.settings.target }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: bindings-${{ matrix.settings.target }}
-          path: ./*.node
-          if-no-files-found: error
-      - name: upload js files
-        if: ${{ matrix.settings.js-files }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: js-files
-          if-no-files-found: error
-          path: |
-            index.js
-            index.d.ts
-  release:
-    needs: build
+  tests:
+    uses: Adjective-Object/good-fences-rs-core/.github/workflows/unittest.yml@main
+  publish:
+    needs:
+      - tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: checkout
+        uses: actions/checkout@v4
         with:
-          path: artifacts
-          merge-multiple: true
+          fetch-depth: 0
+          token: ${{ secrets.BEACHBALL_PUSH_PAT }}
+      - name: pull x86_64-unknown-linux-gnu
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-x86_64-unknown-linux-gnu
+      - name: pull aarch64-unknown-linux-gnu
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-aarch64-unknown-linux-gnu
+      - name: pull x86_64-apple-darwin
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-x86_64-apple-darwin
+      - name: pull aarch64-apple-darwin
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-aarch64-apple-darwin
+      - name: pull x86_64-pc-windows-msvc
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-x86_64-pc-windows-msvc
+      - name: pull aarch64-pc-windows-msvc
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-aarch64-pc-windows-msvc
+      - name: pull js files
+        uses: actions/download-artifact@v4
+        with:
+          name: js-files
       - name: display artifacts
-        run: ls -R artifacts
-      - name: pack platform tarballs
-        shell: bash
+        run: ls -R
+      - name: install deps
+        run: yarn install
+      - name: copy artifacts
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          mkdir -p tarballs
-          for dir in npm/*/; do
-            PKG_JSON="$dir/package.json"
-            # inject version from git tag
-            jq --arg v "$VERSION" '.version = $v' "$PKG_JSON" > "$PKG_JSON.tmp" && mv "$PKG_JSON.tmp" "$PKG_JSON"
-            # find matching .node binary
-            BINARY=$(jq -r .main "$PKG_JSON")
-            if [ -f "artifacts/$BINARY" ]; then
-              cp "artifacts/$BINARY" "$dir/"
-              (cd "$dir" && npm pack --pack-destination ../../tarballs)
-            fi
-          done
-          ls tarballs/
-      - uses: softprops/action-gh-release@v2
+          mkdir artifacts
+          cp *.node artifacts
+          yarn artifacts
+      - uses: actions/setup-node@v4
         with:
-          files: |
-            artifacts/*
-            tarballs/*.tgz
-          generate_release_notes: true
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Check changes
+        id: check_changes
+        run: |
+          git remote set-url origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+          OLD_PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+
+          # Generate changes from beachball, including package.json version bump
+          yarn beachball bump
+
+          # check for changes
+          PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+          if [ "$OLD_PACKAGE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "HAS_CHANGES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HAS_CHANGES=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+      - name: Publish
+        if: ${{ steps.check_changes.outputs.HAS_CHANGES == 'true' }}
+        run: |
+          set -exo pipefail
+
+          git config user.email "mhuan13@gmail.com"
+          git config user.name "$GITHUB_ACTOR"
+
+          # sync new package verson to napi-managed packages (ignored by beachball)
+          yarn napi version -c package.json
+
+          # Commit changes and tag with a version
+          PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+          git commit -am "v$PACKAGE_VERSION"
+
+          # Push updated branch to git main branch
+          git tag "v$PACKAGE_VERSION"
+          git push origin main --tags
+
+          # dependency packages are published via "npm prepublishOnly"
+          # which runs the napi-rs cli under the hood.
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BEACHBALL_PUSH_PAT }}
+          GITHUB_ACTOR: autobot

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -31,6 +31,8 @@ jobs:
           clippy_flags: -- --all-targets -Dwarnings
       - name: run package install script
         shell: bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y openssl libssl3 libssl-dev
@@ -76,6 +78,8 @@ jobs:
       - name: Install container build dependencies
         if: ${{ matrix.settings.container }}
         shell: bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update
           apt-get install -y curl wget git build-essential pkg-config libssl-dev ca-certificates gnupg
@@ -102,6 +106,8 @@ jobs:
       - name: run package install script
         if: ${{ matrix.settings.packages }}
         shell: bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           if command -v sudo &>/dev/null; then
             sudo apt-get update

--- a/change/@good-fences-api-62b0865d-1a0d-4823-b274-d28417ddab42.json
+++ b/change/@good-fences-api-62b0865d-1a0d-4823-b274-d28417ddab42.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix type-only re-export false positives, off-by-one in skip pattern parsing, and CI glibc compatibility",
-  "packageName": "@good-fences/api",
-  "email": "tywalser@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@good-fences-api-bf16202c-7095-4ada-af2a-1454b1413944.json
+++ b/change/@good-fences-api-bf16202c-7095-4ada-af2a-1454b1413944.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix: use thin LTO to preserve NAPI #[ctor] constructors on macOS",
-  "packageName": "@good-fences/api",
-  "email": "michalbiesek@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@good-fences-api-revert-changes.json
+++ b/change/@good-fences-api-revert-changes.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert unintended changes to beachball workflow and package versions",
+  "packageName": "@good-fences/api",
+  "email": "mbiesek@cribl.io",
+  "dependentChangeType": "patch"
+}

--- a/crates/good_fences/src/good_fences_runner.rs
+++ b/crates/good_fences/src/good_fences_runner.rs
@@ -72,7 +72,9 @@ impl GoodFencesRunner {
                     if exclude_patterns.is_empty() {
                         return true;
                     }
-                    !exclude_patterns.iter().any(|pat| pat.matches(&source_file.source_file_path))
+                    !exclude_patterns
+                        .iter()
+                        .any(|pat| pat.matches(&source_file.source_file_path))
                 })
                 .map(|source_file| (source_file.source_file_path.clone(), source_file)),
         );

--- a/crates/import_resolver/src/manual_resolver.rs
+++ b/crates/import_resolver/src/manual_resolver.rs
@@ -253,7 +253,8 @@ mod test {
                     "glob-specifier/lib/*" => vec!["packages/glob-specifier/src/*".to_owned()],
                     "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                 )
-            }
+            },
+            exclude: vec![],
         };
     }
 
@@ -313,6 +314,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module"),
             "../imported/module",
@@ -336,6 +338,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module.ts"),
             "../imported/module",
@@ -359,6 +362,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module.ts"),
             ".",
@@ -382,6 +386,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module.ts"),
             "..",
@@ -405,6 +410,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module.ts"),
             "../imported/module",
@@ -427,6 +433,7 @@ mod test {
                         "non-glob-specifier" => vec!["packages/non-glob-specifier/lib/index".to_owned()]
                     ),
                 },
+                exclude: vec![],
             },
             &RelativePathBuf::from("packages/my/importing/module"),
             "non-glob-specifier",

--- a/crates/tsconfig_paths/src/tsconfig_paths_json.rs
+++ b/crates/tsconfig_paths/src/tsconfig_paths_json.rs
@@ -61,7 +61,10 @@ impl TsconfigPathsJson {
             None => base.map(|b| b.exclude).unwrap_or_default(),
         };
 
-        Ok(TsconfigPathsJson { compiler_options, exclude })
+        Ok(TsconfigPathsJson {
+            compiler_options,
+            exclude,
+        })
     }
 }
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-arm64",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-darwin-x64",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-arm64-gnu",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-linux-x64-gnu",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-arm64-msvc",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api-win32-x64-msvc",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@good-fences/api",
-  "version": "0.20.5",
+  "version": "0.20.0",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
Restore the original beachball-based npm publishing workflow and revert version bumps from 0.20.5 back to 0.20.0. The workflow now triggers on pushes to main branch and uses beachball for automatic version management, instead of manual git tags and GitHub releases.

It was not part of my intentional changes. Sorry